### PR TITLE
Improved check for short scan mode. 

### DIFF
--- a/pmacApp/Db/pmacControllerTrajectory.template
+++ b/pmacApp/Db/pmacControllerTrajectory.template
@@ -136,23 +136,6 @@ record(waveform,"$(P)$(R)VelocityMode") {
 }
 
 
-##
-## Records to specify the acceleration
-##
-record(ao, "$(P)$(R)ProfileAcceleration") {
-  field(DESC, "Acceleration value")
-  field(DTYP, "asynFloat64")
-  field(OUT, "@asyn($(PORT),0)PROFILE_FIXED_TIME")
-  field(PINI, "NO")
-}
-
-record(ai, "$(P)$(R)ProfileAcceleration_RBV") {
-  field(DESC, "Acceleration value")
-  field(DTYP, "asynFloat64")
-  field(INP, "@asyn($(PORT),0)PROFILE_FIXED_TIME")
-  field(SCAN, "I/O Intr")  
-}
-
 ###################################################################
 #  These records control trajectory scan building (pre-execute)   # 
 #                                                                 #

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -401,6 +401,7 @@ class pmacController : public asynMotorController, public pmacCallbackInterface,
 
   // Trajectory scan variables
   bool profileInitialized_;
+  bool tScanShortScan_;           // Is the scan a short scan (< 3.0 seconds)
   int tScanExecuting_;            // Is a scan executing
   int tScanCSNo_;                 // The CS number of the executing scan
   int tScanNumPoints_;            // Total number of points in the scan


### PR DESCRIPTION
 Make sure the driver doesn't report fail if the scan completed quickly.

Tidy up global errors, remove unused records.