### PR TITLE
Implemented readonly mode for motor and axis classes.

### DIFF
--- a/pmacApp/Db/autohome.vdb
+++ b/pmacApp/Db/autohome.vdb
@@ -10,6 +10,7 @@
 # % macro, P, Pv Prefix
 # % macro, PLC, PLC number
 # % macro, PORT,  Serial port to do communications across
+# % macro, CTRL, Controller record name prefix for disabling axis writes
 # % macro, GRP1,  Homing group 1 description
 # % macro, GRP2,  Homing group 2 description
 # % macro, GRP3,  Homing group 3 description
@@ -228,6 +229,12 @@ record(mbbi, "$(P):HM:STATE") {
 
 record(busy, "$(P):HM:HOMING") {
   field(FLNK, "$(P):HM:HOMED")
+}
+
+record(calcout, "$(P):HM:READONLY") {
+  field(CALC, "A")
+  field(INPA, "$(P):HM:HOMING CP")
+  field(OUT, "$(CTRL):AxesReadonly PP")
 }
 
 record(bo, "$(P):HM:HOME") {

--- a/pmacApp/Db/eloss_kill_autohome_records.template
+++ b/pmacApp/Db/eloss_kill_autohome_records.template
@@ -12,7 +12,7 @@
 
 # disable motor when homing
 record(calcout, "$(P)$(M):SDIS") {
-  field(INPA, "$(HOME=$(P)):HM:HOMING CP")
+#  field(INPA, "$(HOME=$(P)):HM:HOMING CP")
 }
 
 # dummy record in case we aren't homing

--- a/pmacApp/Db/pmacController.template
+++ b/pmacApp/Db/pmacController.template
@@ -86,6 +86,31 @@ record(mbbi, "$(P)$(R)COORDINATE_SYS_GROUP_RBV")
    field(SVVL, "7")
 }
 
+#
+# Control read only mode for axes
+#
+record(bo, "$(P)$(R)AxesReadonly")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),0,$(TIMEOUT=4))PMAC_C_AXIS_READONLY")
+    field(VAL, "0")
+    field(ZNAM, "Read/Write")
+    field(ONAM, "Readonly")
+}
+
+#
+# Read back the readonly mode for axes
+# 
+record(bi, "$(P)$(R)AxesReadonly_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),0,$(TIMEOUT=4))PMAC_C_AXIS_READONLY")
+    field(SCAN, "I/O Intr")
+    field(ZNAM, "Read/Write")
+    field(ONAM, "Readonly")
+}
+
 # ///
 # /// Control deferred moves on the controller
 # ///

--- a/pmacApp/src/pmacAxis.cpp
+++ b/pmacApp/src/pmacAxis.cpp
@@ -222,7 +222,7 @@ asynStatus pmacAxis::move(double position, int relative, double min_velocity, do
     limitsDisabled_ = 0;
   }
 #endif
-  status = pC_->lowLevelWriteRead(command, response);
+  status = pC_->axisWriteRead(command, response);
   
   return status;
 }
@@ -325,7 +325,7 @@ asynStatus pmacAxis::home(double min_velocity, double max_velocity, double accel
 	      functionName, pC_->portName, axisNo_, home_type, home_flag, home_velocity, flag_mode, home_offset);
   }
 #endif
-  status = pC_->lowLevelWriteRead(command, response);
+  status = pC_->axisWriteRead(command, response);
 
   return status;
 }
@@ -363,7 +363,7 @@ asynStatus pmacAxis::moveVelocity(double min_velocity, double max_velocity, doub
     limitsDisabled_ = 0;
   }
 #endif
-  status = pC_->lowLevelWriteRead(command, response);
+  status = pC_->axisWriteRead(command, response);
 
   return status;
 }
@@ -405,7 +405,7 @@ asynStatus pmacAxis::stop(double acceleration)
   }
   deferredMove_ = 0;
 
-  status = pC_->lowLevelWriteRead(command, response);
+  status = pC_->axisWriteRead(command, response);
   return status;
 }
 
@@ -427,7 +427,7 @@ asynStatus pmacAxis::setClosedLoop(bool closedLoop)
   } else {
     sprintf(command, "#%d K",  axisNo_);
   }
-  status = pC_->lowLevelWriteRead(command, response);
+  status = pC_->axisWriteRead(command, response);
   return status;
 }
 

--- a/pmacApp/src/pmacCSAxis.cpp
+++ b/pmacApp/src/pmacCSAxis.cpp
@@ -113,7 +113,7 @@ asynStatus pmacCSAxis::move(double position, int relative, double min_velocity, 
       // Abort current move to make sure axes are enabled
       sprintf(commandtemp, "&%dA", pC_->getCSNumber());
       debug(DEBUG_TRACE, functionName, "Sending command to PMAC", commandtemp);
-      status = pC_->immediateWriteRead(commandtemp, response);
+      status = pC_->axisWriteRead(commandtemp, response);
       /* If the program specified is non-zero, add a command to run the program.
        * If program number is zero, then the move will have to be started by some
        * external process, which is a mechanism of allowing coordinated starts to
@@ -121,7 +121,7 @@ asynStatus pmacCSAxis::move(double position, int relative, double min_velocity, 
       sprintf(buff, " B%dR", pC_->getProgramNumber());
       strcat(command, buff);
       debug(DEBUG_TRACE, functionName, "Sending command to PMAC", command);
-      status = pC_->immediateWriteRead(command, response);
+      status = pC_->axisWriteRead(command, response);
   }
 
   return status;
@@ -152,8 +152,8 @@ asynStatus pmacCSAxis::stop(double acceleration)
   sprintf(command, "&%d%sA "DEMAND"="READBACK, pC_->getCSNumber(), acc_buff, axisNo_, axisNo_);
   deferredMove_ = 0;
 
-  debug(DEBUG_ERROR, functionName, "CS Stop command", command);
-  status = pC_->immediateWriteRead(command, response);
+  debug(DEBUG_TRACE, functionName, "CS Stop command", command);
+  status = pC_->axisWriteRead(command, response);
   return status;
 }
 

--- a/pmacApp/src/pmacCSController.cpp
+++ b/pmacApp/src/pmacCSController.cpp
@@ -323,6 +323,24 @@ asynStatus pmacCSController::immediateWriteRead(const char *command, char *respo
   return status;
 }
 
+asynStatus pmacCSController::axisWriteRead(const char *command, char *response)
+{
+  static const char *functionName = "axisWriteRead";
+  asynStatus status = asynSuccess;
+
+  if (!pC_){
+    debug(DEBUG_ERROR,functionName, "ERROR PMAC controller not found");
+    status = asynError;
+  }
+
+  // Send the write/read demand to the PMAC controller
+  if (status == asynSuccess){
+    ((pmacController *)pC_)->axisWriteRead(command, response);
+  }
+
+  return status;
+}
+
 /** Returns a pointer to an pmacAxis object.
   * Returns NULL if the axis number is invalid.
   * \param[in] axisNo Axis index number. */

--- a/pmacApp/src/pmacCSController.h
+++ b/pmacApp/src/pmacCSController.h
@@ -41,6 +41,7 @@ class pmacCSController : public asynMotorController, public pmacCallbackInterfac
     void callback(pmacCommandStore *sPtr, int type);
 
     asynStatus immediateWriteRead(const char *command, char *response);
+    asynStatus axisWriteRead(const char *command, char *response);
 
     pmacCSAxis *getAxis(int axisNo);
 

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -45,6 +45,7 @@
 #define PMAC_C_FastUpdateTimeString    "PMAC_C_FAST_UPDATE_TIME"
 
 #define PMAC_C_AxisCSString            "PMAC_C_AXIS_CS"
+#define PMAC_C_AxisReadonlyString      "PMAC_C_AXIS_READONLY"
 #define PMAC_C_WriteCmdString          "PMAC_C_WRITE_CMD"
 #define PMAC_C_KillAxisString          "PMAC_C_KILL_AXIS"
 #define PMAC_C_PLCBits00String         "PMAC_C_PLC_BITS00"
@@ -200,6 +201,7 @@ class pmacController : public asynMotorController, public pmacCallbackInterface,
 
   //asynStatus printConnectedStatus(void);
   asynStatus immediateWriteRead(const char *command, char *response);
+  asynStatus axisWriteRead(const char *command, char *response);
 
   /* These are the methods that we override */
   asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
@@ -281,6 +283,7 @@ class pmacController : public asynMotorController, public pmacCallbackInterface,
   int PMAC_C_DebugCmd_;
   int PMAC_C_FastUpdateTime_;
   int PMAC_C_AxisCS_;
+  int PMAC_C_AxisReadonly_;
   int PMAC_C_WriteCmd_;
   int PMAC_C_KillAxis_;
   int PMAC_C_PLCBits00_;


### PR DESCRIPTION
Added readonly parameter.
Updated autohome to use the readonly parameter, disabling writes whilst homing.
Updated eloss_kill_autohome_records template to stop disabling the motor record on homing.