### PR TITLE
Added built profile flag.

### DIFF
--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -407,6 +407,7 @@ class pmacController : public asynMotorController, public pmacCallbackInterface,
 
   // Trajectory scan variables
   bool profileInitialized_;
+  bool profileBuilt_;
   bool tScanShortScan_;           // Is the scan a short scan (< 3.0 seconds)
   int tScanExecuting_;            // Is a scan executing
   int tScanCSNo_;                 // The CS number of the executing scan


### PR DESCRIPTION
Added a check for built profiles to ensure a trajectory scan cannot be executed twice without a rebuild.

This is necessary because executing a scan will always invalidate the build state, so executing another
scan straight away would not produce the expected scan.