### PR TITLE
Added the ability to reduce status messages.

### DIFF
--- a/pmacApp/src/pmacMessageBroker.h
+++ b/pmacApp/src/pmacMessageBroker.h
@@ -32,6 +32,8 @@ public:
   asynStatus immediateWriteRead(const char *command, char *response);
   asynStatus addReadVariable(int type, const char *variable);
   asynStatus updateVariables(int type);
+  asynStatus supressStatusReads();
+  asynStatus reinstateStatusReads();
   asynStatus registerForUpdates(pmacCallbackInterface *cbPtr, int type);
   double readUpdateTime();
   asynStatus readStatistics(int *noOfMsgs,
@@ -50,6 +52,10 @@ private:
 
   // Mutex required for locking across threads
   epicsMutex mutex_;
+
+  // Status suppression
+  bool suppressStatus_;
+  int suppressCounter_;
 
   asynUser* ownerAsynUser_;
   asynUser* lowLevelPortUser_;


### PR DESCRIPTION
 When the supress method is called the medium and slow loops stop polling and the fast loop is reduced by a factor of four.  This is to allow the trajectory scan maximum priority when filling buffers.