### PR TITLE
Fix seg fault on startup with no geobrick connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ db
 dbd
 data
 iocs/lab
+iocs/gui
 iocs/lab-ppmac
 .idea
 CMakeLists.txt

--- a/pmacApp/src/pmacAxis.cpp
+++ b/pmacApp/src/pmacAxis.cpp
@@ -65,7 +65,6 @@ pmacAxis::pmacAxis(pmacController *pC, int axisNo)
   asynPrint(pC_->pasynUserSelf, ASYN_TRACE_FLOW, "%s\n", functionName);
 
   //Initialize non-static data members
-  initialised_ = false;
   assignedCS_ = 0;
   setpointPosition_ = 0.0;
   encoderPosition_ = 0.0;
@@ -110,7 +109,7 @@ pmacAxis::pmacAxis(pmacController *pC, int axisNo)
 void pmacAxis::initialSetup(int axisNo) {
   static const char *functionName = "pmacAxis::initialSetup";
 
-  if(pC_->initialised_ && !initialised_) {
+  if(pC_->initialised_) {
 
     //Do an initial poll to get some values from the PMAC
     if (getAxisInitialStatus() != asynSuccess) {
@@ -140,7 +139,6 @@ void pmacAxis::initialSetup(int axisNo) {
 
       pC_->registerForCallbacks(this, pmacMessageBroker::PMAC_FAST_READ);
     }
-    initialised_ = true;
   }
 }
 
@@ -767,8 +765,6 @@ asynStatus pmacAxis::poll(bool *moving) {
   asynStatus status = asynSuccess;
   static const char *functionName = "poll";
   debug(DEBUG_TIMING, functionName, "Poll called");
-
-  initialSetup(axisNo_);
 
   if (axisNo_ != 0) {
     *moving = moving_;

--- a/pmacApp/src/pmacAxis.cpp
+++ b/pmacApp/src/pmacAxis.cpp
@@ -65,6 +65,7 @@ pmacAxis::pmacAxis(pmacController *pC, int axisNo)
   asynPrint(pC_->pasynUserSelf, ASYN_TRACE_FLOW, "%s\n", functionName);
 
   //Initialize non-static data members
+  initialised_ = false;
   assignedCS_ = 0;
   setpointPosition_ = 0.0;
   encoderPosition_ = 0.0;
@@ -99,40 +100,48 @@ pmacAxis::pmacAxis(pmacController *pC, int axisNo)
   /* Set an EPICS exit handler that will shut down polling before asyn kills the IP sockets */
   epicsAtExit(shutdownCallback, pC_);
 
-  //Do an initial poll to get some values from the PMAC
-  if (getAxisInitialStatus() != asynSuccess) {
-    asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
-              "%s: getAxisInitialStatus failed to return asynSuccess. Controller: %s, Axis: %d.\n",
-              functionName, pC_->portName, axisNo_);
-  }
+  initialSetup(axisNo_);
 
-  callParamCallbacks();
-
-  if (axisNo > 0) {
-    char var[16];
-    // Request status readback
-    sprintf(var, "#%d?", axisNo);
-    pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
-    // Request position readback
-    sprintf(var, "#%dP", axisNo);
-    pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
-    // Request following error readback
-    sprintf(var, "#%dF", axisNo);
-    pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
-    // Request ixx24 readback
-    sprintf(var, "i%d24", axisNo);
-    pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
-
-    // Setup any specific hardware status items
-    pC_->pHardware_->setupAxisStatus(axisNo);
-
-    pC_->registerForCallbacks(this, pmacMessageBroker::PMAC_FAST_READ);
-  }
-
-  /* Wake up the poller task which will make it do a poll, 
+  /* Wake up the poller task which will make it do a poll,
    * updating values for this axis to use the new resolution (stepSize_) */
   pC_->wakeupPoller();
+}
 
+void pmacAxis::initialSetup(int axisNo) {
+  static const char *functionName = "pmacAxis::initialSetup";
+
+  if(pC_->initialised_ && !initialised_) {
+
+    //Do an initial poll to get some values from the PMAC
+    if (getAxisInitialStatus() != asynSuccess) {
+      asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
+                "%s: getAxisInitialStatus failed to return asynSuccess. Controller: %s, Axis: %d.\n",
+                functionName, pC_->portName, axisNo_);
+    }
+
+    callParamCallbacks();
+    if (axisNo > 0) {
+      char var[16];
+      // Request status readback
+      sprintf(var, "#%d?", axisNo);
+      pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
+      // Request position readback
+      sprintf(var, "#%dP", axisNo);
+      pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
+      // Request following error readback
+      sprintf(var, "#%dF", axisNo);
+      pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
+      // Request ixx24 readback
+      sprintf(var, "i%d24", axisNo);
+      pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
+
+      // Setup any specific hardware status items
+      pC_->pHardware_->setupAxisStatus(axisNo);
+
+      pC_->registerForCallbacks(this, pmacMessageBroker::PMAC_FAST_READ);
+    }
+    initialised_ = true;
+  }
 }
 
 /**
@@ -554,199 +563,200 @@ asynStatus pmacAxis::getAxisStatus(pmacCommandStore *sPtr) {
 
   asynPrint(pC_->pasynUserSelf, ASYN_TRACE_FLOW, "%s\n", functionName);
 
-  /* Get the time and decide if we want to print errors.*/
-  epicsTimeGetCurrent(&nowTime_);
-  nowTimeSecs_ = nowTime_.secPastEpoch;
-  if ((nowTimeSecs_ - lastTimeSecs_) < pC_->PMAC_ERROR_PRINT_TIME_) {
-    printErrors = 0;
-  } else {
-    printErrors = 1;
-    lastTimeSecs_ = nowTimeSecs_;
-  }
-
-  if (printNextError_) {
-    printErrors = 1;
-  }
-
-  // Parse the axis status
-  axisStatus axStatus;
-  retStatus = pC_->pHardware_->parseAxisStatus(axisNo_, sPtr, axStatus);
-
-
-  setIntegerParam(pC_->PMAC_C_AxisBits01_, axStatus.status16Bit1_);
-  setIntegerParam(pC_->PMAC_C_AxisBits02_, axStatus.status16Bit2_);
-  setIntegerParam(pC_->PMAC_C_AxisBits03_, axStatus.status16Bit3_);
-
-  // Parse the position
-  sprintf(key, "#%dP", axisNo_);
-  value = sPtr->readValue(key);
-  nvals = sscanf(value.c_str(), "%lf", &enc_position);
-  if (nvals != 1) {
-    asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
-              "%s: Failed to parse position. Key: %s  Value: %s\n",
-              functionName, key, value.c_str());
-    retStatus |= asynError;
-  }
-
-  // Parse the following error or encoder channel
-  if (encoder_axis_ != 0) {
-    sprintf(key, "#%dP", encoder_axis_);
-  } else {
-    // Encoder position comes back on this axis - note we initially read
-    // the following error into the position variable
-    sprintf(key, "#%dF", axisNo_);
-  }
-  value = sPtr->readValue(key);
-  nvals = sscanf(value.c_str(), "%lf", &position);
-  if (nvals != 1) {
-    asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
-              "%s: Failed to parse following error. Key: %s  Value: %s\n",
-              functionName, key, value.c_str());
-    retStatus |= asynError;
-  }
-
-
-  if (retStatus == asynSuccess) {
-
-    //int homeSignal = ((status[1] & pC_->PMAC_STATUS2_HOME_COMPLETE) != 0);
-    int direction = 0;
-
-    // For closed loop axes, position is actually following error up to this point
-    if (encoder_axis_ == 0) {
-      position += enc_position;
-    }
-
-    // Store the raw position
-    rawPosition_ = position;
-
-    position *= scale_;
-    enc_position *= scale_;
-
-    setDoubleParam(pC_->motorPosition_, position);
-    setDoubleParam(pC_->motorEncoderPosition_, enc_position);
-
-    // Use previous position and current position to calculate direction.
-    if ((position - previous_position_) > 0) {
-      direction = 1;
-    } else if (position - previous_position_ == 0.0) {
-      direction = previous_direction_;
+  if(pC_->initialised_) {
+    /* Get the time and decide if we want to print errors.*/
+    epicsTimeGetCurrent(&nowTime_);
+    nowTimeSecs_ = nowTime_.secPastEpoch;
+    if ((nowTimeSecs_ - lastTimeSecs_) < pC_->PMAC_ERROR_PRINT_TIME_) {
+      printErrors = 0;
     } else {
-      direction = 0;
-    }
-    setIntegerParam(pC_->motorStatusDirection_, direction);
-    // Store position to calculate direction for next poll.
-    previous_position_ = position;
-    previous_direction_ = direction;
-
-    // Test that we initiated a move, were moving and have now
-    // stopped moving.  In this case we must update the cached
-    // position.
-    if (moving_ && initiatedMove_ && axStatus.done_) {
-      initiatedMove_ = false;
-      cachedPosition_ = rawPosition_;
-      debug(DEBUG_TRACE, functionName, "Updating cached position after move complete",
-            cachedPosition_);
+      printErrors = 1;
+      lastTimeSecs_ = nowTimeSecs_;
     }
 
-    moving_ = !axStatus.done_ || deferredMove_;
+    if (printNextError_) {
+      printErrors = 1;
+    }
 
-    // Read the currently assigned CS for the axis, and whether it is assigned at all
-    assignedCS_ = axStatus.currentCS_;
+    // Parse the axis status
+    axisStatus axStatus;
+    retStatus = pC_->pHardware_->parseAxisStatus(axisNo_, sPtr, axStatus);
 
-    // Set the currently assigned CS number
-    setIntegerParam(pC_->PMAC_C_AxisCS_, assignedCS_);
 
-    setIntegerParam(pC_->motorStatusHighLimit_, axStatus.highLimit_);
-    setIntegerParam(pC_->motorStatusHomed_, axStatus.home_);
+    setIntegerParam(pC_->PMAC_C_AxisBits01_, axStatus.status16Bit1_);
+    setIntegerParam(pC_->PMAC_C_AxisBits02_, axStatus.status16Bit2_);
+    setIntegerParam(pC_->PMAC_C_AxisBits03_, axStatus.status16Bit3_);
 
-    setIntegerParam(pC_->motorStatusMoving_, moving_);
-    setIntegerParam(pC_->motorStatusDone_, !moving_);
+    // Parse the position
+    sprintf(key, "#%dP", axisNo_);
+    value = sPtr->readValue(key);
+    nvals = sscanf(value.c_str(), "%lf", &enc_position);
+    if (nvals != 1) {
+      asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
+                "%s: Failed to parse position. Key: %s  Value: %s\n",
+                functionName, key, value.c_str());
+      retStatus |= asynError;
+    }
 
-    setIntegerParam(pC_->motorStatusLowLimit_, axStatus.lowLimit_);
-    setIntegerParam(pC_->motorStatusFollowingError_, axStatus.followingError_);
-    fatal_following_ = axStatus.followingError_;
+    // Parse the following error or encoder channel
+    if (encoder_axis_ != 0) {
+      sprintf(key, "#%dP", encoder_axis_);
+    } else {
+      // Encoder position comes back on this axis - note we initially read
+      // the following error into the position variable
+      sprintf(key, "#%dF", axisNo_);
+    }
+    value = sPtr->readValue(key);
+    nvals = sscanf(value.c_str(), "%lf", &position);
+    if (nvals != 1) {
+      asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
+                "%s: Failed to parse following error. Key: %s  Value: %s\n",
+                functionName, key, value.c_str());
+      retStatus |= asynError;
+    }
 
-    // Need to make sure that we can write the CNEN flag, by setting the gain support flag in the status word
-    setIntegerParam(pC_->motorStatusGainSupport_, 1);
-    // Reflect PMAC_STATUS1_OPEN_LOOP in the CNEN Flag. CNEN can be set from the (user) motor record via the motorAxisClosedLoop command
-    setIntegerParam(pC_->motorStatusPowerOn_, axStatus.power_);
 
-    axisProblemFlag = 0;
-    // Set any axis specific general problem bits.
-    if (((axStatus.status24Bit1_ & pC_->PMAX_AXIS_GENERAL_PROB1) != 0) ||
-        ((axStatus.status24Bit2_ & pC_->PMAX_AXIS_GENERAL_PROB2) != 0)) {
-      if (printErrors) {
-        asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
-                  "*** Warning *** axis %d problem status0=%x status1=%x \n",
-                  axisNo_, axStatus.status24Bit1_, axStatus.status24Bit2_);
-        printNextError_ = false;
+    if (retStatus == asynSuccess) {
+
+      //int homeSignal = ((status[1] & pC_->PMAC_STATUS2_HOME_COMPLETE) != 0);
+      int direction = 0;
+
+      // For closed loop axes, position is actually following error up to this point
+      if (encoder_axis_ == 0) {
+        position += enc_position;
       }
-      axisProblemFlag = 1;
-    }
 
-    int globalStatus = 0;
-    int feedrate_problem = 0;
-    pC_->getIntegerParam(0, pC_->PMAC_C_GlobalStatus_, &globalStatus);
-    pC_->getIntegerParam(0, pC_->PMAC_C_FeedRateProblem_, &feedrate_problem);
-    if (globalStatus || feedrate_problem) {
-      if (printErrors) {
-        asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
-                  "*** Warning *** %d problem globalStatus=%x feedrate_problem=%x \n",
-                  axisNo_, globalStatus, feedrate_problem);
-        printNextError_ = false;
+      // Store the raw position
+      rawPosition_ = position;
+
+      position *= scale_;
+      enc_position *= scale_;
+
+      setDoubleParam(pC_->motorPosition_, position);
+      setDoubleParam(pC_->motorEncoderPosition_, enc_position);
+
+      // Use previous position and current position to calculate direction.
+      if ((position - previous_position_) > 0) {
+        direction = 1;
+      } else if (position - previous_position_ == 0.0) {
+        direction = previous_direction_;
+      } else {
+        direction = 0;
       }
-      axisProblemFlag = 1;
-    }
-    // Check limits disabled bit in ix24, and if we haven't intentially disabled limits
-    // because we are homing, set the motorAxisProblem bit. Also check the limitsCheckDisable
-    // flag, which the user can set to disable this feature.*/
-    if (!limitsCheckDisable_) {
-      // Check we haven't intentially disabled limits for homing.
-      if (!limitsDisabled_) {
-        // Parse ixx24
-        sprintf(key, "i%d24", axisNo_);
-        value = sPtr->readValue(key);
-        sscanf(value.c_str(), "$%x", &limitsDisabledBit);
+      setIntegerParam(pC_->motorStatusDirection_, direction);
+      // Store position to calculate direction for next poll.
+      previous_position_ = position;
+      previous_direction_ = direction;
+
+      // Test that we initiated a move, were moving and have now
+      // stopped moving.  In this case we must update the cached
+      // position.
+      if (moving_ && initiatedMove_ && axStatus.done_) {
+        initiatedMove_ = false;
+        cachedPosition_ = rawPosition_;
+        debug(DEBUG_TRACE, functionName, "Updating cached position after move complete",
+              cachedPosition_);
+      }
+
+      moving_ = !axStatus.done_ || deferredMove_;
+
+      // Read the currently assigned CS for the axis, and whether it is assigned at all
+      assignedCS_ = axStatus.currentCS_;
+
+      // Set the currently assigned CS number
+      setIntegerParam(pC_->PMAC_C_AxisCS_, assignedCS_);
+
+      setIntegerParam(pC_->motorStatusHighLimit_, axStatus.highLimit_);
+      setIntegerParam(pC_->motorStatusHomed_, axStatus.home_);
+
+      setIntegerParam(pC_->motorStatusMoving_, moving_);
+      setIntegerParam(pC_->motorStatusDone_, !moving_);
+
+      setIntegerParam(pC_->motorStatusLowLimit_, axStatus.lowLimit_);
+      setIntegerParam(pC_->motorStatusFollowingError_, axStatus.followingError_);
+      fatal_following_ = axStatus.followingError_;
+
+      // Need to make sure that we can write the CNEN flag, by setting the gain support flag in the status word
+      setIntegerParam(pC_->motorStatusGainSupport_, 1);
+      // Reflect PMAC_STATUS1_OPEN_LOOP in the CNEN Flag. CNEN can be set from the (user) motor record via the motorAxisClosedLoop command
+      setIntegerParam(pC_->motorStatusPowerOn_, axStatus.power_);
+
+      axisProblemFlag = 0;
+      // Set any axis specific general problem bits.
+      if (((axStatus.status24Bit1_ & pC_->PMAX_AXIS_GENERAL_PROB1) != 0) ||
+          ((axStatus.status24Bit2_ & pC_->PMAX_AXIS_GENERAL_PROB2) != 0)) {
+        if (printErrors) {
+          asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
+                    "*** Warning *** axis %d problem status0=%x status1=%x \n",
+                    axisNo_, axStatus.status24Bit1_, axStatus.status24Bit2_);
+          printNextError_ = false;
+        }
+        axisProblemFlag = 1;
+      }
+
+      int globalStatus = 0;
+      int feedrate_problem = 0;
+      pC_->getIntegerParam(0, pC_->PMAC_C_GlobalStatus_, &globalStatus);
+      pC_->getIntegerParam(0, pC_->PMAC_C_FeedRateProblem_, &feedrate_problem);
+      if (globalStatus || feedrate_problem) {
+        if (printErrors) {
+          asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
+                    "*** Warning *** %d problem globalStatus=%x feedrate_problem=%x \n",
+                    axisNo_, globalStatus, feedrate_problem);
+          printNextError_ = false;
+        }
+        axisProblemFlag = 1;
+      }
+      // Check limits disabled bit in ix24, and if we haven't intentially disabled limits
+      // because we are homing, set the motorAxisProblem bit. Also check the limitsCheckDisable
+      // flag, which the user can set to disable this feature.*/
+      if (!limitsCheckDisable_) {
+        // Check we haven't intentially disabled limits for homing.
+        if (!limitsDisabled_) {
+          // Parse ixx24
+          sprintf(key, "i%d24", axisNo_);
+          value = sPtr->readValue(key);
+          sscanf(value.c_str(), "$%x", &limitsDisabledBit);
 //          printf("Axis %d ixx24: %d\n", axisNo_, limitsDisabledBit);
-        limitsDisabledBit = ((0x20000 & limitsDisabledBit) >> 17);
-        if (limitsDisabledBit) {
-          axisProblemFlag = 1;
-          if (printErrors) {
-            asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
-                      "*** WARNING *** Limits are disabled on controller %s, axis %d\n",
-                      pC_->portName, axisNo_);
-            printNextError_ = false;
+          limitsDisabledBit = ((0x20000 & limitsDisabledBit) >> 17);
+          if (limitsDisabledBit) {
+            axisProblemFlag = 1;
+            if (printErrors) {
+              asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
+                        "*** WARNING *** Limits are disabled on controller %s, axis %d\n",
+                        pC_->portName, axisNo_);
+              printNextError_ = false;
+            }
           }
         }
       }
-    }
-    setIntegerParam(pC_->motorStatusProblem_, axisProblemFlag);
+      setIntegerParam(pC_->motorStatusProblem_, axisProblemFlag);
 
-    // Clear error print flag for this axis if problem has been removed.
-    if (axisProblemFlag == 0) {
-      printNextError_ = true;
+      // Clear error print flag for this axis if problem has been removed.
+      if (axisProblemFlag == 0) {
+        printNextError_ = true;
+      }
     }
-  }
 
 #ifdef REMOVE_LIMITS_ON_HOME
-  if (limitsDisabled_ && (axStatus.status24Bit2_ & pC_->PMAC_STATUS2_HOME_COMPLETE) &&
-      (axStatus.status24Bit1_ & pC_->PMAC_STATUS1_DESIRED_VELOCITY_ZERO)) {
-    // Re-enable limits
-    sprintf(command, "i%d24=i%d24&$FDFFFF", axisNo_, axisNo_);
-    cmdStatus = pC_->lowLevelWriteRead(command, response);
-    limitsDisabled_ = (cmdStatus != 0);
-  }
+    if (limitsDisabled_ && (axStatus.status24Bit2_ & pC_->PMAC_STATUS2_HOME_COMPLETE) &&
+        (axStatus.status24Bit1_ & pC_->PMAC_STATUS1_DESIRED_VELOCITY_ZERO)) {
+      // Re-enable limits
+      sprintf(command, "i%d24=i%d24&$FDFFFF", axisNo_, axisNo_);
+      cmdStatus = pC_->lowLevelWriteRead(command, response);
+      limitsDisabled_ = (cmdStatus != 0);
+    }
 #endif
-  // Set amplifier enabled bit.
-  setIntegerParam(pC_->motorStatusPowerOn_, axStatus.ampEnabled_);
-  amp_enabled_ = axStatus.ampEnabled_;
+    // Set amplifier enabled bit.
+    setIntegerParam(pC_->motorStatusPowerOn_, axStatus.ampEnabled_);
+    amp_enabled_ = axStatus.ampEnabled_;
 
-  if (amp_enabled_ != amp_enabled_prev_) {
-    debugf(DEBUG_TRACE, functionName, "Axis %d amp enabled changed ==> %d",
-           axisNo_, amp_enabled_);
-    amp_enabled_prev_ = amp_enabled_;
+    if (amp_enabled_ != amp_enabled_prev_) {
+      debugf(DEBUG_TRACE, functionName, "Axis %d amp enabled changed ==> %d",
+             axisNo_, amp_enabled_);
+      amp_enabled_prev_ = amp_enabled_;
+    }
   }
-
   return asynSuccess;
 }
 
@@ -757,6 +767,8 @@ asynStatus pmacAxis::poll(bool *moving) {
   asynStatus status = asynSuccess;
   static const char *functionName = "poll";
   debug(DEBUG_TIMING, functionName, "Poll called");
+
+  initialSetup(axisNo_);
 
   if (axisNo_ != 0) {
     *moving = moving_;

--- a/pmacApp/src/pmacAxis.h
+++ b/pmacApp/src/pmacAxis.h
@@ -70,7 +70,6 @@ private:
 
     double getPosition();
 
-    bool initialised_;
     int assignedCS_;
     double setpointPosition_;
     double encoderPosition_;

--- a/pmacApp/src/pmacAxis.h
+++ b/pmacApp/src/pmacAxis.h
@@ -27,6 +27,8 @@ public:
 
     virtual ~pmacAxis();
 
+    void initialSetup(int axisNo);
+
     asynStatus move(double position, int relative, double min_velocity, double max_velocity,
                     double acceleration);
 
@@ -68,6 +70,7 @@ private:
 
     double getPosition();
 
+    bool initialised_;
     int assignedCS_;
     double setpointPosition_;
     double encoderPosition_;

--- a/pmacApp/src/pmacCSAxis.cpp
+++ b/pmacApp/src/pmacCSAxis.cpp
@@ -30,20 +30,21 @@ pmacCSAxis::pmacCSAxis(pmacCSController *pController, int axisNo)
   printNextError_ = false;
   moving_ = false;
 
-  if (axisNo > 0) {
-    char var[16];
-    // Request position readback
-    sprintf(var, "&%dQ8%d", pC_->getCSNumber(), axisNo_);
-    pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
+  if (pC_->initialised()) {
+    if (axisNo > 0) {
+      char var[16];
+      // Request position readback
+      sprintf(var, "&%dQ8%d", pC_->getCSNumber(), axisNo_);
+      pC_->monitorPMACVariable(pmacMessageBroker::PMAC_FAST_READ, var);
 
-    // Register for callbacks
-    pC_->registerForCallbacks(this, pmacMessageBroker::PMAC_FAST_READ);
+      // Register for callbacks
+      pC_->registerForCallbacks(this, pmacMessageBroker::PMAC_FAST_READ);
+    }
+
+    // Wake up the poller task which will make it do a poll,
+    // updating values for this axis to use the new resolution (stepSize_)
+    pC_->wakeupPoller();
   }
-
-  // Wake up the poller task which will make it do a poll,
-  // updating values for this axis to use the new resolution (stepSize_)
-  pC_->wakeupPoller();
-
 }
 
 pmacCSAxis::~pmacCSAxis() {

--- a/pmacApp/src/pmacCSController.cpp
+++ b/pmacApp/src/pmacCSController.cpp
@@ -140,7 +140,6 @@ pmacCSController::pmacCSController(const char *portName, const char *controllerP
                               1, // autoconnect
                               0, 0),  // Default priority and stack size
           pmacDebugger("pmacCSController"),
-          initialised_(false),
           portName_(portName),
           csNumber_(csNo),
           progNumber_(program),
@@ -190,18 +189,10 @@ pmacCSController::pmacCSController(const char *portName, const char *controllerP
               "%s Unable To Set Driver Parameters In Constructor.\n", functionName);
   }
 
-  initialSetup();
+  pC_->registerCS(this, portName, csNumber_);
 }
 
 pmacCSController::~pmacCSController() {
-}
-
-void pmacCSController::initialSetup(void) {
-  if (pC_->initialised_ && !initialised_) {
-    // Registration with the main controller. Register this coordinate system
-    pC_->registerCS(this, portName, csNumber_);
-    initialised_ = true;
-  }
 }
 
 std::string pmacCSController::getPortName() {

--- a/pmacApp/src/pmacCSController.h
+++ b/pmacApp/src/pmacCSController.h
@@ -44,6 +44,8 @@ public:
 
     virtual ~pmacCSController();
 
+    void initialSetup(void);
+
     std::string getPortName();
 
     asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
@@ -112,13 +114,14 @@ protected:
 #define LAST_PMAC_CS_PARAM PMAC_CS_LastParam_
 
 private:
+    bool initialised_;
     std::string portName_;
     int csNumber_;
     int progNumber_;
     epicsUInt32 movesDeferred_;
     int status_[3];
     csStatus cStatus_;
-    void *pC_;
+    pmacController *pC_;
     // csMoveTime_ defines how long a programmed move takes. The value of this parameter is always
     // put into Q70 before a call to PROG10 on the brick. A value of 0 means that the motion
     // will execute as fast as possible and the slowest motor will determine the time.

--- a/pmacApp/src/pmacCSController.h
+++ b/pmacApp/src/pmacCSController.h
@@ -41,43 +41,23 @@ class pmacCSController
 
 public:
     pmacCSController(const char *portName, const char *controllerPortName, int csNo, int program);
-
     virtual ~pmacCSController();
-
-    void initialSetup(void);
-
     std::string getPortName();
-
     asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
-
     asynStatus writeFloat64(asynUser *pasynUser, epicsFloat64 value);
-
     void setDebugLevel(int level, int axis);
-
     bool getMoving();
-
     int getCSNumber();
-
     double getAxisResolution(int axis);
-
     double getAxisOffset(int axis);
-
     int getProgramNumber();
-
     csStatus getStatus();
-
     std::string getVelocityCmd(double velocity, double steps);
-
     std::string getCSAccTimeCmd(double time);
-
     void callback(pmacCommandStore *sPtr, int type);
-
     asynStatus immediateWriteRead(const char *command, char *response);
-
     asynStatus axisWriteRead(const char *command, char *response);
-
     pmacCSAxis *getAxis(asynUser *pasynUser);
-
     pmacCSAxis *getAxis(int axisNo);
 
     // Registration for callbacks
@@ -85,18 +65,13 @@ public:
 
     // Add PMAC variable/status item to monitor
     asynStatus monitorPMACVariable(int poll_speed, const char *var);
-
     asynStatus tScanCheckForErrors();
-
     asynStatus tScanCheckProgramRunning(int *running);
 
     // Ensure CS demands (Q71..9) are consistent after a motor move or CS change
     asynStatus makeCSDemandsConsistent();
-
     asynStatus pmacSetAxisScale(int axis, int scale);
-
     asynStatus wakeupPoller();
-
     asynStatus pmacCSSetAxisDirectMapping(int axis, int mappedAxis);
 
 protected:
@@ -114,7 +89,6 @@ protected:
 #define LAST_PMAC_CS_PARAM PMAC_CS_LastParam_
 
 private:
-    bool initialised_;
     std::string portName_;
     int csNumber_;
     int progNumber_;

--- a/pmacApp/src/pmacCSController.h
+++ b/pmacApp/src/pmacCSController.h
@@ -42,6 +42,7 @@ class pmacCSController
 public:
     pmacCSController(const char *portName, const char *controllerPortName, int csNo, int program);
     virtual ~pmacCSController();
+    bool initialised(void);
     std::string getPortName();
     asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
     asynStatus writeFloat64(asynUser *pasynUser, epicsFloat64 value);

--- a/pmacApp/src/pmacCSMonitor.cpp
+++ b/pmacApp/src/pmacCSMonitor.cpp
@@ -24,11 +24,14 @@ pmacCSMonitor::pmacCSMonitor(pmacController *pController) :
 pmacCSMonitor::~pmacCSMonitor() {
 }
 
-asynStatus pmacCSMonitor::registerCS(pmacCSController *csPtr, int csNo) {
-  // Add the CS to the list
-  pCSControllers_[csNo] = csPtr;
-
-  return asynSuccess;
+bool pmacCSMonitor::registerCS(pmacCSController *csPtr, int csNo) {
+  if(pCSControllers_[csNo] == NULL) {
+    // Add the CS to the list
+    pCSControllers_[csNo] = csPtr;
+    return true;
+  } else {
+    return false;
+  }
 }
 
 asynStatus pmacCSMonitor::poll(bool *moving) {
@@ -36,8 +39,12 @@ asynStatus pmacCSMonitor::poll(bool *moving) {
   bool anyMoving = false;
 
   for (i = 0; i < 16; i++) {
-    if (!pCSControllers_[i]) continue;
-    if (pCSControllers_[i]->getMoving()) anyMoving = true;
+    if (!pCSControllers_[i]) {
+      continue;
+    }
+    if (pCSControllers_[i]->getMoving()) {
+      anyMoving = true;
+    }
   }
   *moving = anyMoving;
   return asynSuccess;

--- a/pmacApp/src/pmacCSMonitor.h
+++ b/pmacApp/src/pmacCSMonitor.h
@@ -22,7 +22,8 @@ public:
     virtual ~pmacCSMonitor();
 
     // Register a coordinate system with this controller
-    asynStatus registerCS(pmacCSController *csPtr, int csNo);
+    // return false if it is already registered
+    bool registerCS(pmacCSController *csPtr, int csNo);
 
     asynStatus poll(bool *moving);
 

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -405,6 +405,7 @@ public:
     pmacCsGroups *pGroupList;
 
 private:
+    void completeRegisterCS(int csNo);
     int connected_;
     int initialised_;
     int cid_;

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -198,30 +198,21 @@ public:
     pmacController(const char *portName, const char *lowLevelPortName, int lowLevelPortAddress,
                    int numAxes, double movingPollPeriod,
                    double idlePollPeriod);
-
     virtual ~pmacController();
-
+    asynStatus checkConnection();
+    asynStatus initialSetup();
+    void createAsynParams(void);
+    void initAsynParams(void);
+    void setupBrokerVariables(void);
     void startPMACPolling();
-
     void setDebugLevel(int level, int axis, int csNo);
 
-    asynStatus
-    drvUserCreate(asynUser *pasynUser, const char *drvInfo, const char **pptypeName, size_t *psize);
-
+    asynStatus drvUserCreate(asynUser *pasynUser, const char *drvInfo, const char **pptypeName, size_t *psize);
     asynStatus processDrvInfo(char *input, char *output);
-
     virtual void callback(pmacCommandStore *sPtr, int type);
-
-    asynStatus checkConnection();
-
-    asynStatus initialiseConnection();
-
     asynStatus slowUpdate(pmacCommandStore *sPtr);
-
     asynStatus mediumUpdate(pmacCommandStore *sPtr);
-
     asynStatus fastUpdate(pmacCommandStore *sPtr);
-
     asynStatus parseIntegerVariable(const std::string &command,
                                     const std::string &response,
                                     const std::string &desc,
@@ -229,64 +220,42 @@ public:
 
     //asynStatus printConnectedStatus(void);
     asynStatus immediateWriteRead(const char *command, char *response);
-
     asynStatus axisWriteRead(const char *command, char *response);
 
     /* These are the methods that we override */
     asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
-
     asynStatus writeFloat64(asynUser *pasynUser, epicsFloat64 value);
-
     asynStatus writeFloat64Array(asynUser *pasynUser, epicsFloat64 *value, size_t nElements);
-
     asynStatus writeInt32Array(asynUser *pasynUser, epicsInt32 *value, size_t nElements);
-
     asynStatus writeOctet(asynUser *pasynUser, const char *value, size_t nChars, size_t *nActual);
 
-    asynStatus
-    readEnum(asynUser *pasynUser, char *strings[], int values[], int severities[], size_t nElements,
+    asynStatus readEnum(asynUser *pasynUser, char *strings[], int values[], int severities[], size_t nElements,
              size_t *nIn);
 
     void report(FILE *fp, int level);
-
     pmacAxis *getAxis(asynUser *pasynUser);
-
     pmacAxis *getAxis(int axisNo);
-
     asynStatus poll();
 
     // Trajectory scanning methods
     asynStatus initializeProfile(size_t maxPoints);
-
     asynStatus buildProfile();
-
     asynStatus buildProfile(int csNo);
-
     asynStatus appendToProfile();
-
     asynStatus preparePMAC();
-
     asynStatus executeProfile();
-
     asynStatus executeProfile(int csNo);
-
     asynStatus abortProfile();
 
     void trajectoryTask();
-
     void setBuildStatus(int state, int status, const std::string &message);
-
     void setAppendStatus(int state, int status, const std::string &message);
-
     void setProfileStatus(int state, int status, const std::string &message);
-
     asynStatus sendTrajectoryDemands(int buffer);
-
     asynStatus doubleToPMACFloat(double value, int64_t *representation);
 
     //Disable the check for disabled hardware limits.
     asynStatus pmacDisableLimitsCheck(int axis);
-
     asynStatus pmacDisableLimitsCheck(void);
 
     //Set the axis scale factor.
@@ -312,19 +281,12 @@ public:
 
     // List PLC program
     asynStatus listPLCProgram(int plcNo, char *buffer, size_t size);
-
     asynStatus storeKinematics();
-
     asynStatus listKinematic(int csNo, const std::string &type, char *buffer, size_t size);
-
     asynStatus executeManualGroup();
-
     asynStatus updateCsAssignmentParameters();
-
     asynStatus tScanBuildProfileArray(double *positions, int axis, int numPoints);
-
     asynStatus tScanIncludedAxes(int *axisMask);
-
     void registerForLock(asynPortDriver *controller);
 
 protected:

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -201,6 +201,7 @@ public:
     virtual ~pmacController();
     asynStatus checkConnection();
     asynStatus initialSetup();
+    bool initialised(void);
     void createAsynParams(void);
     void initAsynParams(void);
     void setupBrokerVariables(void);
@@ -405,7 +406,6 @@ public:
     pmacCsGroups *pGroupList;
 
 private:
-    void completeRegisterCS(int csNo);
     int connected_;
     int initialised_;
     int cid_;

--- a/pmacApp/src/pmacMessageBroker.h
+++ b/pmacApp/src/pmacMessageBroker.h
@@ -117,6 +117,9 @@ private:
     // number of registered locks
     int lock_count;
 
+    // connection status;
+    bool connected_;
+
     static const epicsUInt32 PMAC_MAXBUF_;
     static const epicsFloat64 PMAC_TIMEOUT_;
 };

--- a/pmacApp/unitTests/test_PMACMessageBroker.cpp
+++ b/pmacApp/unitTests/test_PMACMessageBroker.cpp
@@ -87,12 +87,16 @@ BOOST_AUTO_TEST_CASE(test_PMACMessageBroker)
 
   // Try to send a write/read
   strcpy(command, "TEST COMMAND");
-  BOOST_CHECK_EQUAL(pMB->immediateWriteRead(command, response), asynError);
+  BOOST_CHECK_EQUAL(pMB->immediateWriteRead(command, response), asynDisconnected);
 
-  // Connect to the mock driver
+  // Connect to the mock drive
   BOOST_CHECK_EQUAL(pMB->connect(mockport.c_str(), 0), asynSuccess);
 
   // Check the broker is connected
+  // getConnectedStatus now sends a blank message to check connection
+  // the message is 0 long and the OK response is 2 characters,
+  // readStatistics expected results were altered accordingly
+  pMock->setResponse("OK");
   BOOST_CHECK_NO_THROW(pMB->getConnectedStatus(&connected));
   BOOST_CHECK_EQUAL(connected, 1);
 
@@ -167,11 +171,11 @@ BOOST_AUTO_TEST_CASE(test_PMACMessageBroker)
                                         &lastMsgTime), asynSuccess);
 
   // Verify the number of messages sent is 4
-  BOOST_CHECK_EQUAL(noOfMsgs, 4);
+  BOOST_CHECK_EQUAL(noOfMsgs, 5);
   // Verify total bytes written is 41
   BOOST_CHECK_EQUAL(totalBytesWritten, 41);
   // Verify total bytes read is 31
-  BOOST_CHECK_EQUAL(totalBytesRead, 31);
+  BOOST_CHECK_EQUAL(totalBytesRead, 33);
   // Verify total message time is greater than 0
   BOOST_CHECK_GT(totalMsgTime, 0);
   // Verify last message bytes written is 9


### PR DESCRIPTION
This is a bug fix to avoid a seg fault if an IOC is started when the pmac controller is switched off or disconnected.

The solution was to split out some of the functionality of constructors for the essential classes. The extracted code only gets run if a connection has been made.

I tried to allow for a later connection to complete setup and allow normal operation but this proved too difficult. I managed to get the errors down to a minimum and print a message to say a reboot is required to use the disconnected device (a multi device IOC with one missing would work).

This is quite a significant and invasive change. However all system tests still run successfully.

I'm not sure if any of the suggested reviewers have the time or inclination to understand this quite complex pull request but thought I would attempt to adhere to protocol anyway :-)