### PR TITLE
Poll All Now feature

### DIFF
--- a/pmacApp/Db/pmacController.template
+++ b/pmacApp/Db/pmacController.template
@@ -28,6 +28,17 @@
 #
 
 ##############################################################
+# Ensure all PVs are up to date with the current brick state
+##############################################################
+record(busy,"$(P):PollAllNow") {
+    field(DESC,"Poll brick status")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),0)PMAC_C_POLLALLNOW")
+    field(ZNAM, "Done")
+    field(ONAM, "Polling")
+}
+
+##############################################################
 # Control deferred mode for all real 1axes in this brick
 ##############################################################
 record(bo, "$(P):DeferMoves")

--- a/pmacApp/Db/pmacDirectMotor.template
+++ b/pmacApp/Db/pmacDirectMotor.template
@@ -23,6 +23,7 @@
 ##############################################################
 # Set immediate demand for this motor
 ##############################################################
+#% archiver 0.5 Monitor
 record(ao, "$(P)$(M):DirectDemand")
 {
     field(FLNK, "$(P)$(M):DirectCountsCalc.PROC")

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -25,6 +25,7 @@
 #define PMAC_C_FirstParamString           "PMAC_C_FIRSTPARAM"
 #define PMAC_C_LastParamString            "PMAC_C_LASTPARAM"
 
+#define PMAC_C_PollAllNowString           "PMAC_C_POLLALLNOW"
 #define PMAC_C_StopAllString              "PMAC_C_STOPALL"
 #define PMAC_C_KillAllString              "PMAC_C_KILLALL"
 #define PMAC_C_GlobalStatusString         "PMAC_C_GLOBALSTATUS"
@@ -204,6 +205,7 @@ public:
     bool initialised(void);
     void createAsynParams(void);
     void initAsynParams(void);
+    void pollAllNow(void);
     void setupBrokerVariables(void);
     void startPMACPolling();
     void setDebugLevel(int level, int axis, int csNo);
@@ -297,6 +299,7 @@ protected:
 #define FIRST_PMAC_PARAM PMAC_C_FirstParam_
     int PMAC_C_StopAll_;
     int PMAC_C_KillAll_;
+    int PMAC_C_PollAllNow_;
     int PMAC_C_GlobalStatus_;
     int PMAC_C_CommsError_;
     int PMAC_C_FeedRate_;


### PR DESCRIPTION
This feature added at Tom's request. When a trajectory scan is aborted he needs a way to guarantee that the GPIO readbacks reflect the state of the brick. Forcing a poll removes the inherent race condition.

Here we provide a busy record which forces all the polled variables be read from the brick.

This is generally useful where any process needs to synchronize brick state. 