### PR TITLE
Fix reading CS status

### DIFF
--- a/configure/CONFIG_SITE.linux-x86_64.Common
+++ b/configure/CONFIG_SITE.linux-x86_64.Common
@@ -18,10 +18,10 @@ USE_GRAPHICSMAGICK=NO
 # EPICS_LIBCOM_ONLY=YES
 
 # Definitions required for compiling the unit tests
-BOOST           = /dls_sw/prod/tools/RHEL6-x86_64/boost/1-48-0/prefix
-BOOST_LIB       = $(BOOST)/lib
+BOOST           = /usr
+BOOST_LIB       = $(BOOST)/lib/x86_64-linux-gnu
 BOOST_INCLUDE   = -I$(BOOST)/include
 
 SSH             = /usr
-SSH_LIB         = $(SSH)/lib64
+SSH_LIB         = $(SSH)/lib/x86_64-linux-gnu
 SSH_INCLUDE     = -I$(SSH)/include

--- a/configure/RELEASE.linux-x86_64.Common
+++ b/configure/RELEASE.linux-x86_64.Common
@@ -1,6 +1,6 @@
 # The following definitions must be changed for each site
 
-SUPPORT       = /dls_sw/prod/R3.14.12.7/support
-WORK          = /dls_sw/work/R3.14.12.7/support
-EPICS_BASE    = /dls_sw/epics/R3.14.12.7/base
+SUPPORT       = /usr/local/epics/synApps/support
+WORK          = /usr/local/epics/synApps/support
+EPICS_BASE    = /usr/local/epics/base
 

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -6,9 +6,9 @@
 # WORK            = /dls_sw/work/R3.14.12.7/support
 # EPICS_BASE      = /dls_sw/epics/R3.14.12.7/base
 
-ASYN=       $(SUPPORT)/asyn/4-33
-CALC=       $(SUPPORT)/calc/3-7
-MOTOR=      $(SUPPORT)/motor/6-10-1dls1
-BUSY=       $(SUPPORT)/busy/1-7
+ASYN=       $(SUPPORT)/asyn-R4-33
+CALC=       $(SUPPORT)/calc-R3-7-1
+MOTOR=      $(SUPPORT)/motor-R6-10-1
+BUSY=       $(SUPPORT)/busy-R1-7
 
 

--- a/iocs/simple-power-pmac/configure/RELEASE
+++ b/iocs/simple-power-pmac/configure/RELEASE
@@ -1,11 +1,11 @@
 # TODO edit this file to reflect your site dependencies locations
 
-SUPPORT = /dls_sw/prod/R3.14.12.7/support
+SUPPORT = /usr/local/epics/synApps/support
 # Module definitions
-ASYN = $(SUPPORT)/asyn/4-33
-BUSY = $(SUPPORT)/busy/1-7
-CALC = $(SUPPORT)/calc/3-7
-MOTOR = /home/hgv27681/R3.14.12.7/support/motor
-PMAC = /home/hgv27681/R3.14.12.7/support/pmac
+ASYN = $(SUPPORT)/asyn-R4-33
+BUSY = $(SUPPORT)/busy-R1-7
+CALC = $(SUPPORT)/calc-R3-7-1
+MOTOR = $(SUPPORT)/motor-R6-10-1
+PMAC = /usr/local/epics/apps/pmac
 # EPICS Base appears last
-EPICS_BASE = /dls_sw/epics/R3.14.12.7/base
+EPICS_BASE = /usr/local/epics/base

--- a/iocs/simple-power-pmac/iocBoot/ioclab/Makefile
+++ b/iocs/simple-power-pmac/iocBoot/ioclab/Makefile
@@ -7,7 +7,7 @@ TOP = ../..
 include $(TOP)/configure/CONFIG
 
 SCRIPTS += ../stlab.sh
-SCRIPTS += stlab.boot
+#SCRIPTS += stlab.boot
 PATH := $(PATH):/dls_sw/epics/R3.14.12.7/extensions/bin/linux-x86_64
 
 include $(TOP)/configure/RULES

--- a/iocs/simple-power-pmac/iocBoot/ioclab/stlab.sh
+++ b/iocs/simple-power-pmac/iocBoot/ioclab/stlab.sh
@@ -13,4 +13,5 @@ if [ -n "$1" ]; then
         exit 1
     }
 fi
-exec ./lab stlab.boot
+export INSTALL=/usr/local/epics/apps/pmac/iocs/simple-power-pmac
+exec ../../bin/linux-x86_64/lab stlab.src

--- a/pmacApp/src/pmacCSController.cpp
+++ b/pmacApp/src/pmacCSController.cpp
@@ -403,7 +403,7 @@ void pmacCSController::callback(pmacCommandStore *sPtr, int type) {
 
   debug(DEBUG_TRACE, functionName, "Coordinate system status callback");
 
-  if(type == pmacMessageBroker::PMAC_PRE_FAST_READ) {
+  if(type == pmacMessageBroker::PMAC_FAST_READ) {
     // Parse the status
     ((pmacController *) pC_)->pHardware_->parseCSStatus(csNumber_, sPtr, cStatus_);
     status_[0] = cStatus_.stat1_;
@@ -766,6 +766,3 @@ epicsRegisterFunction(pmacCreateCSAxes);
 epicsRegisterFunction(pmacCSSetAxisScale);
 #endif
 } // extern "C"
-
-
-

--- a/pmacApp/unitTests/test_IntegerHashtable.cpp
+++ b/pmacApp/unitTests/test_IntegerHashtable.cpp
@@ -131,9 +131,9 @@ BOOST_AUTO_TEST_CASE(test_IntHashtableMemory)
 
   // Record the base memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   process_mem_usage(vm_base, res_base);
-  BOOST_MESSAGE("VM: " << vm_base << "; RSS: " << res_base);
+  BOOST_TEST_MESSAGE("VM: " << vm_base << "; RSS: " << res_base);
 
   // Insert a value 10 times
   for (int index = 0; index < 10; index++){
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(test_IntHashtableMemory)
   }
   // Record the base memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   // Verify memory usage change less than 1%
   BOOST_CHECK_CLOSE(vm/vm_base, 1.0, 1.0);
   BOOST_CHECK_CLOSE(res/res_base, 1.0, 1.0);
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(test_IntHashtableMemory)
 
   // Check memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   // Verify memory usage change less than 1%
   BOOST_CHECK_CLOSE(vm/vm_base, 1.0, 1.0);
   BOOST_CHECK_CLOSE(res/res_base, 1.0, 1.0);
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(test_IntHashtableMemory)
 
   // Check memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   // Verify memory usage change less than 1%
   BOOST_CHECK_CLOSE(vm/vm_base, 1.0, 1.0);
   BOOST_CHECK_CLOSE(res/res_base, 1.0, 1.0);
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(test_IntHashtableMemory)
 
   // Check memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   // Verify memory usage change less than 1%
   BOOST_CHECK_CLOSE(vm/vm_base, 1.0, 1.0);
   BOOST_CHECK_CLOSE(res/res_base, 1.0, 1.0);

--- a/pmacApp/unitTests/test_StringHashtable.cpp
+++ b/pmacApp/unitTests/test_StringHashtable.cpp
@@ -134,9 +134,9 @@ BOOST_AUTO_TEST_CASE(test_HashtableMemory)
 
   // Record the base memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   process_mem_usage(vm_base, res_base);
-  BOOST_MESSAGE("VM: " << vm_base << "; RSS: " << res_base);
+  BOOST_TEST_MESSAGE("VM: " << vm_base << "; RSS: " << res_base);
 
   // Insert a value 10 times
   for (int index = 0; index < 10; index++){
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(test_HashtableMemory)
   }
   // Record the base memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   // Verify memory usage change less than 1%
   BOOST_CHECK_CLOSE(vm/vm_base, 1.0, 1.0);
   BOOST_CHECK_CLOSE(res/res_base, 1.0, 1.0);
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_HashtableMemory)
 
   // Check memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   // Verify memory usage change less than 1%
   BOOST_CHECK_CLOSE(vm/vm_base, 1.0, 1.0);
   BOOST_CHECK_CLOSE(res/res_base, 1.0, 1.0);
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(test_HashtableMemory)
 
   // Check memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   // Verify memory usage change less than 1%
   BOOST_CHECK_CLOSE(vm/vm_base, 1.0, 1.0);
   BOOST_CHECK_CLOSE(res/res_base, 1.0, 1.0);
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(test_HashtableMemory)
 
   // Check memory usage
   process_mem_usage(vm, res);
-  BOOST_MESSAGE("VM: " << vm << "; RSS: " << res);
+  BOOST_TEST_MESSAGE("VM: " << vm << "; RSS: " << res);
   // Verify memory usage change less than 1%
   BOOST_CHECK_CLOSE(vm/vm_base, 1.0, 1.0);
   BOOST_CHECK_CLOSE(res/res_base, 1.0, 1.0);


### PR DESCRIPTION
I was trying to create a virtual motor in order to drive a slit setup with Power PMAC, then I came across the problem that the DMOV was not returning to stop condition. 

I studied the code and debug it. I find out that the `callback` function on `pmacCSController.cpp` file never pass through the if that compare type with a constant due to their different values. 

I printed the `type` variable and its value is 2, which means that a fast read call this function, not pre fast read.

This solution solved my problem, so I am creating this pull request to collaborate with this driver. I would appreciate if you consider my request.

I could be wrong on my hypothesis that it is a fast read, not a pre fast read. Maybe we need to change `type` value, not the constant.

In case of any suggestions, feel free to contact me. 