### PR TITLE
Fix/build warnings

### DIFF
--- a/configure/CONFIG_SITE.linux-x86_64.Common
+++ b/configure/CONFIG_SITE.linux-x86_64.Common
@@ -17,11 +17,9 @@ USE_GRAPHICSMAGICK=NO
 # built with this flag
 # EPICS_LIBCOM_ONLY=YES
 
-# Definitions required for compiling the unit tests
-BOOST           = /dls_sw/prod/tools/RHEL6-x86_64/boost/1-48-0/prefix
-BOOST_LIB       = $(BOOST)/lib
-BOOST_INCLUDE   = -I$(BOOST)/include
-
 SSH             = /usr
 SSH_LIB         = $(SSH)/lib64
 SSH_INCLUDE     = -I$(SSH)/include
+
+# Build unit tests (requires BOOST)
+WITH_BOOST = YES

--- a/etc/builder.py
+++ b/etc/builder.py
@@ -980,13 +980,9 @@ class RunCommand(Device):
 
 # hiding templates which are just used in includes so as to not
 # dirty the auto list of builder objects (is this the best way to do this?)
-class _hide1(AutoSubstitution):
+class _pmacDirectMotorTemplate(AutoSubstitution):
     TemplateFile = 'pmacDirectMotor.template'
 
 
-class _hide2(AutoSubstitution):
+class _pmacCsAxisTemplate(AutoSubstitution):
     TemplateFile = 'pmac_cs_axis.template'
-
-
-class _hide3(AutoSubstitution):
-    TemplateFile = 'pmacDirectMotor.template'

--- a/pmacApp/Db/pmacDirectMotor.template
+++ b/pmacApp/Db/pmacDirectMotor.template
@@ -16,7 +16,6 @@
 # % macro, PORT, The asyn port (motor controller or CS controller)
 # % macro, ADDR, The asyn address (real or CS axis number)
 # % macro, DESC, Description
-# % macro, PMAC, PV Prefix for the motor controller
 # % macro, P, PV Prefix for direct motors
 # % macro, M, Motor PV suffix ('Mx' for real and 'CSx:My' for CS axes)
 

--- a/pmacApp/pmacAsynIPPortSrc/pmacAsynIPPort.c
+++ b/pmacApp/pmacAsynIPPortSrc/pmacAsynIPPort.c
@@ -367,7 +367,7 @@ static asynStatus readResponse(pmacPvt *pPmacPvt, asynUser *pasynUser, size_t ma
     status = pPmacPvt->poctet->read(pPmacPvt->octetPvt,
       pasynUser,pPmacPvt->inBuf,maxchars,&thisRead,eomReason);
 
-    asynPrint(pasynUser,ASYN_TRACE_FLOW, "%s readResponse1 maxchars=%d, thisRead=%d, eomReason=%d, status=%d\n",pPmacPvt->portName, maxchars, thisRead, *eomReason, status);     
+    asynPrint(pasynUser,ASYN_TRACE_FLOW, "%s readResponse1 maxchars=%zd, thisRead=%zd, eomReason=%d, status=%u\n",pPmacPvt->portName, maxchars, thisRead, *eomReason, status);     
     if (status == asynTimeout && thisRead == 0 && pasynUser->timeout>0) {
          /* failed to read as many characters as required into the input buffer, 
             check for more response data on the PMAC */
@@ -381,7 +381,7 @@ static asynStatus readResponse(pmacPvt *pPmacPvt, asynUser *pasynUser, size_t ma
 	    status = pPmacPvt->poctet->read(pPmacPvt->octetPvt,
 	      pasynUser,pPmacPvt->inBuf,maxchars,&thisRead,eomReason);
                
-            asynPrint(pasynUser,ASYN_TRACE_FLOW, "%s readResponse2 maxchars=%d, thisRead=%d, eomReason=%d, status=%d\n",pPmacPvt->portName, maxchars, thisRead, *eomReason, status);                    
+            asynPrint(pasynUser,ASYN_TRACE_FLOW, "%s readResponse2 maxchars=%zd, thisRead=%zd, eomReason=%d, status=%u\n",pPmacPvt->portName, maxchars, thisRead, *eomReason, status);                    
         } 
     } 
           
@@ -435,7 +435,7 @@ static int pmacReadReady(pmacPvt *pPmacPvt, asynUser *pasynUser )
              retval = 1;
          }    
          asynPrintIO(pasynUser,ASYN_TRACE_FLOW,data,thisRead,
-             "%s read pmacReadReady OK thisRead=%d\n",pPmacPvt->portName,thisRead);
+             "%s read pmacReadReady OK thisRead=%zd\n",pPmacPvt->portName,thisRead);
     } else {
         asynPrint(pasynUser,ASYN_TRACE_ERROR, "%s read pmacReadReady failed status=%d,retval=%d",pPmacPvt->portName,status,retval);
     }
@@ -480,7 +480,7 @@ static int pmacFlush(pmacPvt *pPmacPvt, asynUser *pasynUser )
          asynPrint(pasynUser,ASYN_TRACE_FLOW, "%s read pmacFlush OK\n",pPmacPvt->portName);
          retval = 1;    
     } else {
-        asynPrint(pasynUser,ASYN_TRACE_ERROR, "%s read pmacFlush failed - thisRead=%d, eomReason=%d, status=%d\n",pPmacPvt->portName, thisRead, eomReason, status);
+        asynPrint(pasynUser,ASYN_TRACE_ERROR, "%s read pmacFlush failed - thisRead=%zd, eomReason=%d, status=%d\n",pPmacPvt->portName, thisRead, eomReason, status);
     }
 
     pPmacPvt->inBufTail = 0;
@@ -613,7 +613,7 @@ static asynStatus readIt(void *ppvt,asynUser *pasynUser,
     }
     *nbytesTransfered = nRead;
     
-    asynPrintIO(pasynUser,ASYN_TRACE_FLOW, data, *nbytesTransfered, "%s pmacAsynIPPort readIt nbytesTransfered=%d, eomReason=%d, status=%d\n",pPmacPvt->portName,*nbytesTransfered, *eomReason, status);
+    asynPrintIO(pasynUser,ASYN_TRACE_FLOW, data, *nbytesTransfered, "%s pmacAsynIPPort readIt nbytesTransfered=%zd, eomReason=%d, status=%d\n",pPmacPvt->portName,*nbytesTransfered, *eomReason, status);
              
 	asynPrint( pasynUser, ASYN_TRACE_FLOW, "pmacAsynIPPort::readIt. END\n" );
 
@@ -642,13 +642,13 @@ static asynStatus sendPmacGetBuffer(pmacPvt *pPmacPvt, asynUser *pasynUser, size
 static asynStatus flushIt(void *ppvt,asynUser *pasynUser)
 {
     pmacPvt *pPmacPvt = (pmacPvt *)ppvt;
-    asynStatus status = asynSuccess;
+    asynStatus status;
     asynPrint( pasynUser, ASYN_TRACE_FLOW, "pmacAsynIPPort::flushIt\n" );
     assert(pPmacPvt);
 
     pmacFlush (pPmacPvt, pasynUser);
     status = pPmacPvt->poctet->flush(pPmacPvt->octetPvt,pasynUser);
-    return asynSuccess;
+    return status;
 }
 
 static asynStatus registerInterruptUser(void *ppvt,asynUser *pasynUser,

--- a/pmacApp/pmacAsynVMEPortSrc/pmacDriver.c
+++ b/pmacApp/pmacAsynVMEPortSrc/pmacDriver.c
@@ -13,6 +13,7 @@
 /* vxWorks headers */
 #include <iosLib.h>    /* For DEV_HDR, iosDrvCreate and iosDevAdd */
 #include <logLib.h>    /* For logMsg */
+#include <taskLib.h>   /* For taskDelay */
 
 /* EPICS headers */
 #include <epicsRingBytes.h>

--- a/pmacApp/src/pmacCsGroups.cpp
+++ b/pmacApp/src/pmacCsGroups.cpp
@@ -151,7 +151,7 @@ asynStatus pmacCsGroups::switchToGroup(int id) {
   static const char *functionName = "switchToGroup";
   char command[PMAC_MAXBUF] = {0};
   char response[PMAC_MAXBUF] = {0};
-  asynStatus cmdStatus;
+  asynStatus cmdStatus = asynSuccess;
   pmacCsGroup *pGrp;
   pmacCsAxisDefList *pAxisDefs;
   debug(DEBUG_FLOW, functionName);

--- a/pmacApp/src/pmacMessageBroker.cpp
+++ b/pmacApp/src/pmacMessageBroker.cpp
@@ -12,6 +12,7 @@ const epicsFloat64 pmacMessageBroker::PMAC_TIMEOUT_ = 2.0;
 
 pmacMessageBroker::pmacMessageBroker(asynUser *pasynUser) :
         pmacDebugger("pmacMessageBroker"),
+        disable_poll(false),
         suppressStatus_(false),
         suppressCounter_(0),
         powerPMAC_(false),
@@ -27,8 +28,7 @@ pmacMessageBroker::pmacMessageBroker(asynUser *pasynUser) :
         updateTime_(0.0),
         lock_count(0),
         connected_(false),
-        newConnection_(true),
-        disable_poll(false)
+        newConnection_(true)
 {
   epicsTimeGetCurrent(&this->writeTime_);
   epicsTimeGetCurrent(&this->startTime_);

--- a/pmacApp/unitTests/Makefile
+++ b/pmacApp/unitTests/Makefile
@@ -5,7 +5,7 @@ include $(TOP)/configure/CONFIG
 #=============================
 # The unit test executable with the actual unit tests depends on the boost 
 # unit test framework so we can only build it if boost has been configured
-ifdef BOOST
+ifeq ($(WITH_BOOST), YES)
   PROD_IOC_Linux += pmac-test
   pmac-test_SRCS += pmac-test.cpp
   pmac-test_SRCS += pmacTestUtilities.cpp  
@@ -22,12 +22,11 @@ ifdef BOOST
 
   # Add pmac tests for new classes like this:
   #pmac-test_SRCS += test_<test name>.cpp
-  
-  #pmac-test_LIBS += boost_unit_test_framework
+
   pmac-test_LIBS += pmacAsynMotorPort
   pmac-test_LIBS += asyn
-	pmac-test_LIBS += $(EPICS_BASE_IOC_LIBS)
-  #boost_unit_test_framework_DIR=$(BOOST_LIB)
+  pmac-test_LIBS += $(EPICS_BASE_IOC_LIBS)
+
   ifdef BOOST_LIB
     boost_unit_test_framework_DIR=$(BOOST_LIB)
     pmac-test_LIBS += boost_unit_test_framework

--- a/pmacApp/unitTests/MockPMACAsynDriver.cpp
+++ b/pmacApp/unitTests/MockPMACAsynDriver.cpp
@@ -13,7 +13,6 @@
 MockPMACAsynDriver::MockPMACAsynDriver(const char *portName, double delay, int noAutoConnect) :
   asynPortDriver(portName,
                  0,
-                 0,
                  asynOctetMask,
                  asynOctetMask,
                  ASYN_CANBLOCK,

--- a/pmacApp/unitTests/test_IntegerHashtable.cpp
+++ b/pmacApp/unitTests/test_IntegerHashtable.cpp
@@ -123,7 +123,6 @@ BOOST_AUTO_TEST_CASE(test_IntHashtable)
 BOOST_AUTO_TEST_CASE(test_IntHashtableMemory)
 {
   IntegerHashtable t1;
-  int value;
   double vm = 0.0;
   double res = 0.0;
   double vm_base = 0.0;


### PR DESCRIPTION
Some small changes:

- Remove some compiler warnings that appeared when building on a Diamond RHEL7 workstation
- Remove unused PMAC macro from pmacDirectMotor.template
- Now uses system boost library instead of RHEL6 tool