### PR TITLE
Improve handling of setting soft limits on the PMAC controller

### DIFF
--- a/pmacApp/src/Makefile
+++ b/pmacApp/src/Makefile
@@ -69,6 +69,9 @@ pmacAsynMotorPort_SRCS += pmacCallbackInterface.cpp
 # do debug build
 # CXXFLAGS= -g -O0 -fPIC
 
+# Enable wonderful C++ 11 features
+USR_CXXFLAGS_Linux += -std=c++11
+
 # specify all source files to be compiled and added to the library
 #pmac_SRCS += xxx
 

--- a/pmacApp/src/pmacAxis.cpp
+++ b/pmacApp/src/pmacAxis.cpp
@@ -188,8 +188,6 @@ asynStatus pmacAxis::getAxisInitialStatus(void) {
   char command[PMAC_MAXBUF] = {0};
   char response[PMAC_MAXBUF] = {0};
   int cmdStatus = 0;
-  double low_limit = 0.0;
-  double high_limit = 0.0;
   double pgain = 0.0;
   double igain = 0.0;
   double dgain = 0.0;
@@ -203,7 +201,7 @@ asynStatus pmacAxis::getAxisInitialStatus(void) {
 
     sprintf(command, "I%d13 I%d14 I%d30 I%d31 I%d33", axisNo_, axisNo_, axisNo_, axisNo_, axisNo_);
     cmdStatus = pC_->lowLevelWriteRead(command, response);
-    nvals = sscanf(response, "%lf %lf %lf %lf %lf", &high_limit, &low_limit, &pgain, &dgain,
+    nvals = sscanf(response, "%lf %lf %lf %lf %lf", &highLimit_, &lowLimit_, &pgain, &dgain,
                    &igain);
 
     if (cmdStatus || nvals != 5) {
@@ -211,8 +209,8 @@ asynStatus pmacAxis::getAxisInitialStatus(void) {
                 "%s: Error: initial status poll failed on axis %d.\n", functionName, axisNo_);
       return asynError;
     } else {
-      setDoubleParam(pC_->motorLowLimit_, low_limit * scale_);
-      setDoubleParam(pC_->motorHighLimit_, high_limit * scale_);
+      setDoubleParam(pC_->motorLowLimit_, lowLimit_ * scale_);
+      setDoubleParam(pC_->motorHighLimit_, highLimit_ * scale_);
       setDoubleParam(pC_->motorPGain_, pgain);
       setDoubleParam(pC_->motorIGain_, igain);
       setDoubleParam(pC_->motorDGain_, dgain);


### PR DESCRIPTION
The current behaviour of this driver is to set the ix13 and ix14 values based on the dial high and low limits (respectively) from the motor record directly without any special checks.

However, this can caused potentially undesired effects. Setting ix13 or ix14 to zero disables them on the controller, even if only one of these values are zero. This can be a problem if e.g. a user wants to set the soft limits of a stage from 0-180 degrees, but one of these values corresponds to zero counts and disables that soft limit. Whilst the motor record does prevent demands being sent from outside of this range, this does disable checking on the brick when doing co-ordinated motion via a motion program.

The other consideration is that DHLM=DLLM=0 should mean the limits are disabled based on R4-4 notes: https://epics-modules.github.io/motor/motor_release.html (I'm not sure why this isn't reference in the manual at https://epics.anl.gov/bcda/synApps/motor/motorRecord.html).

So this PR changes the behaviour of the driver in terms of enabling/disabling the soft limits on the controller. An example for the high soft limit is below (the low soft limit is the same, but swap ix13 and ix14):

- User updates the dial limit value which changes the high soft limit, ix13 (including via the user limit fields)
- If the requested value is 0, and the other limit is 0, ix13 and ix14 are both set to 0 (disables soft limit checks)
- If the requested value is 0, but the other limit is non-zero, then set ix13 to 1 (keeps requested soft limit enabled)
- If the requested value is non-zero, and the other limit is 0,  then set ix13 to the requested value and ix14 to 1 (makes sure that both soft limits are enabled)
- If the requested value is non-zero, and the other limit is non-zero, then set ix13 to the requested value (updates soft limit value, both soft limits will be enabled)
