### PR TITLE
pmacAxis: set raw encoder position to match motor position when not u…

### DIFF
--- a/pmacApp/src/pmacAxis.cpp
+++ b/pmacApp/src/pmacAxis.cpp
@@ -749,6 +749,8 @@ asynStatus pmacAxis::getAxisStatus(pmacCommandStore *sPtr) {
             // For closed loop axes, position is actually following error up to this point
             if (encoder_axis_ == 0) {
                 position += enc_position;
+                // Now restore the encoder position to match
+                enc_position = position;
             }
 
             // Store the raw position


### PR DESCRIPTION
…sing different encoder channel

When polling the axis position for axis which isn't using a separate encoder channel the encoder position variable `enc_position` is used to store the following error:

```
// Parse the following error or encoder channel
if (encoder_axis_ != 0) {
    sprintf(key, "#%dP", encoder_axis_);
} else {
    // Encoder position comes back on this axis - note we initially read
    // the following error into the position variable
    sprintf(key, "#%dF", axisNo_);
}
value = sPtr->readValue(key);
nvals = sscanf(value.c_str(), "%lf", &enc_position);
```

It then just sets the raw encoder position field to be equal to the following error, rather than restore it to match the raw motor position first.

So this PR now sets `enc_position` and `position` to be equal in the case that `encoder_axis_ == 0`.