### PR TITLE
Minor power pmac changes: maximum axes (builder) and debug messages

### DIFF
--- a/etc/builder.py
+++ b/etc/builder.py
@@ -547,6 +547,11 @@ class _pmacStatusAxis(AutoSubstitution):
     TemplateFile = 'pmacStatusAxis.template'
 
 
+class GeoBricketteMStop(AutoSubstitution):
+    """Creates some PVs for monitoring motion stop specific to a GeoBrickette pmac"""
+    TemplateFile = 'geobrickette_motion_stop.template'
+
+
 class _CsControlT(AutoSubstitution):
     TemplateFile = "pmacCsController.template"
     Dependencies = (Pmac,)

--- a/etc/builder.py
+++ b/etc/builder.py
@@ -278,7 +278,7 @@ class PowerPMAC(DeltaTau):
         self.statusT = _powerPmacStatusT(PORT=name, P=self.P)
 
         # instantiate an axis status template for each axis
-        assert self.NAxes in range(1,33), "Number of axes (%d) must be in range 1..32" % self.NAxes
+        assert self.NAxes in range(1,257), "Number of axes (%d) must be in range 1..256" % self.NAxes
         self.axes = []
         # for each axis
         for i in range(1, self.NAxes + 1):

--- a/pmacApp/Db/Makefile
+++ b/pmacApp/Db/Makefile
@@ -33,7 +33,7 @@ DB += encoder_readback.template
 DB += run_plc.template
 DB += run_command.template
 DB += motion_stop.template
-
+DB += geobrickette_motion_stop.template
 
 # The following templates are used for Coordinate Systems
 DB += dls_pmac_cs_asyn_motor.template

--- a/pmacApp/Db/autohome.template
+++ b/pmacApp/Db/autohome.template
@@ -11,31 +11,31 @@
 # % macro, PLC, PLC number
 # % macro, PORT,  Serial port to do communications across
 # % macro, CTRL, Controller record name prefix for disabling axis writes
-# % macro, GRP1,  Homing group 1 description
-# % macro, GRP2,  Homing group 2 description
-# % macro, GRP3,  Homing group 3 description
-# % macro, GRP4,  Homing group 4 description
-# % macro, GRP5,  Homing group 5 description
-# % macro, GRP6,  Homing group 6 description
-# % macro, GRP7,  Homing group 7 description
-# % macro, GRP8,  Homing group 8 description
-# % macro, GRP9,  Homing group 9 description
-# % macro, GRP10, Homing group 10 description
-# % macro, STATE11, Homing state 11 description
-# % macro, STATE12, Homing state 12 description
-# % macro, STATE13, Homing state 13 description
-# % macro, STATE14, Homing state 14 description
-# % macro, STATE15, Homing state 15 description
-# % macro, STATUS11, Homing status 11 description (e.g. for custom limit checks)
-# % macro, STATUS12, Homing status 12 description (e.g. for custom limit checks)
-# % macro, STATUS13, Homing status 13 description (e.g. for custom limit checks)
-# % macro, STATUS14, Homing status 14 description (e.g. for custom limit checks)
-# % macro, STATUS15, Homing status 15 description (e.g. for custom limit checks)
-# % macro, STATUSSV11, Homing status 11 severity
-# % macro, STATUSSV12, Homing status 12 severity
-# % macro, STATUSSV13, Homing status 13 severity
-# % macro, STATUSSV14, Homing status 14 severity
-# % macro, STATUSSV15, Homing status 15 severity
+# % macro, GRP1, Optional.  Homing group 1 description.  Defaults to "All".
+# % macro, GRP2, Optional.  Homing group 2 description.  Defaults to give empty description string.
+# % macro, GRP3, Optional.  Homing group 3 description.  Defaults to give empty description string.
+# % macro, GRP4, Optional.  Homing group 4 description.  Defaults to give empty description string.
+# % macro, GRP5, Optional.  Homing group 5 description.  Defaults to give empty description string.
+# % macro, GRP6, Optional.  Homing group 6 description.  Defaults to give empty description string.
+# % macro, GRP7, Optional.  Homing group 7 description.  Defaults to give empty description string.
+# % macro, GRP8, Optional.  Homing group 8 description.  Defaults to give empty description string.
+# % macro, GRP9, Optional.  Homing group 9 description.  Defaults to give empty description string.
+# % macro, GRP10, Optional.  Homing group 10 description.  Defaults to give empty description string.
+# % macro, STATE11, Optional.  Homing state 11 description.  Defaults to give empty description string.
+# % macro, STATE12, Optional.  Homing state 12 description.  Defaults to give empty description string.
+# % macro, STATE13, Optional.  Homing state 13 description.  Defaults to give empty description string.
+# % macro, STATE14, Optional.  Homing state 14 description.  Defaults to give empty description string.
+# % macro, STATE15, Optional.  Homing state 15 description.  Defaults to give empty description string.
+# % macro, STATUS11, Optional.  Homing status 11 description (e.g. for custom limit checks).  Defaults to give empty description string.
+# % macro, STATUS12, Optional.  Homing status 12 description (e.g. for custom limit checks).  Defaults to give empty description string.
+# % macro, STATUS13, Optional.  Homing status 13 description (e.g. for custom limit checks).  Defaults to give empty description string.
+# % macro, STATUS14, Optional.  Homing status 14 description (e.g. for custom limit checks).  Defaults to give empty description string.
+# % macro, STATUS15, Optional.  Homing status 15 description (e.g. for custom limit checks).  Defaults to give empty description string.
+# % macro, STATUSSV11, Optional.  Homing status 11 severity.  Defaults to NO_ALARM.
+# % macro, STATUSSV12, Optional.  Homing status 12 severity.  Defaults to NO_ALARM.
+# % macro, STATUSSV13, Optional.  Homing status 13 severity.  Defaults to NO_ALARM.
+# % macro, STATUSSV14, Optional.  Homing status 14 severity.  Defaults to NO_ALARM.
+# % macro, STATUSSV15, Optional.  Homing status 15 severity.  Defaults to NO_ALARM.
 # % macro, DESC, Description
 
 # % macro, name, Object name and gui association name

--- a/pmacApp/Db/geobrickette_motion_stop.template
+++ b/pmacApp/Db/geobrickette_motion_stop.template
@@ -1,0 +1,73 @@
+# File geobrickette_motion_stop.template
+#
+# % macro, __doc__, To read the motion stop info and interpret the status for a pmac GeoBrickette.  They do motion stop in firmware and (unlike earlier pmac models like GeoBricks and pmac/umac systems) do not need PLC2.
+#
+# The relevant variable values are read but never written.
+#
+# % macro, P,           Mandatory.                           The PV device name prefix for the GeoBrickette for the motion stop.
+# % macro, PORT,        Mandatory.                           The PMAC GeoBrickette serial comms port.
+#
+# % macro, TIMEOUT,     Optional.  Defaults to 5.            The asyn timeout - the EPICS aysn record TMOT fields.
+# % macro, SCAN,        Optional.  Defaults to 5 second.     The scan rate on the status records - the EPICS record SCAN fields.
+# % macro, mstop_VAR,   Optional.  Defaults to M7647.        The pmac variable containing the Motion stop status.
+# % macro, active_VAR,  Optional.  Defaults to I35.          The pmac variable containing the Motion stop active status.  If this is not set to active then the GeoBrickette will IGNORE its motion stop input signal.  While it is sometimes made inactive during commissioning, it should not be the case during operation when it should be active.
+#
+# % macro, mstop_R,     Optional.  Defaults to :MOTIONSTOP   The record prefix for motion stop.
+# % macro, mstop_DESC,  Optional.  Defaults to motion stop.  The description of the motion stop signal.
+# % macro, mstop_ZNAM,  Optional.  Defaults to Stopped.      The zero value string label for the Motion Stop status - the EPICS record ZNAM field.
+# % macro, mstop_ONAM,  Optional.  Defaults to Not Stopped.  The one value string label for the Motion Stop status - the EPICS record ONAM field.
+# % macro, mstop_ZSV,   Optional.  Defaults to MAJOR.        The zero value motion stop alarm severity - the EPICS record ZSV field.
+# % macro, mstop_OSV,   Optional.  Defaults to NO_ALARM.     The one value motion stop alarm severity - the EPICS record OSV field.
+#
+# % macro, active_R,    Optional.  Defaults to :MOTIONSTOP_ACTIVE   The record prefix for active status.
+# % macro, active_DESC, Optional.  Defaults to mstop active. The description of the motion stop signal.
+# % macro, active_ZNAM, Optional.  Defaults to Not Active.   The zero value string label for the active status - the EPICS record ZNAM field.
+# % macro, active_ONAM, Optional.  Defaults to Active.       The one value string label for the active status - the EPICS record ONAM field.
+# % macro, active_ZSV,  Optional.  Defaults to MINOR.        The zero value alarm severity for the active status - the EPICS record ZSV field.
+# % macro, active_OSV,  Optional.  Defaults to NO_ALARM.     The one value alarm severity for the active status - the EPICS record OSV field.
+#
+
+# Record to read the specified motion stop variable from the GeoBrickette.
+#
+record(asyn, "$(P)$(mstop_R=:MOTIONSTOP):GET") {
+  field(DESC, "Get $(P) $(mstop_DESC=motion stop) status")
+  field(DTYP, "asynRecordDevice")
+  field(PORT, "$(PORT)")
+  field(TMOT, "$(TIMEOUT=5)")
+  field(AOUT, "$(mstop_VAR=M7647)")
+}
+
+# The motion stop readback status value with interpreted levels.
+# Defaults appropriate for the usual motion stop requirements.
+record(bi, "$(P)$(mstop_R=:MOTIONSTOP):RBV") {
+  field(DESC, "$(P) $(mstop_DESC=motion stop) readback" )
+  field(INP,  "$(P)(mstop_R=:MOTIONSTOP):GET.AINP PP")
+  field(SCAN, "$(SCAN=5 second)")
+  field(ZNAM, "$(mstop_ZNAM=Stopped)")
+  field(ZSV,  "$(mstop_ZSV=MAJOR)")
+  field(ONAM, "$(mstop_ONAM=Not Stopped)")
+  field(OSV,  "$(mstop_OSV=NO_ALARM)")
+}
+
+# Record to read the specified motion stop active variable from the GeoBrickette.
+# 
+record(asyn, "$(P)$(active_R=:MOTIONSTOP_ACTIVE):GET") {
+  field(DESC, "Get $(P) $(active_DESC=mstop active) status")
+  field(DTYP, "asynRecordDevice")
+  field(PORT, "$(PORT)")
+  field(TMOT, "$(TIMEOUT=5)")
+  field(AOUT, "$(active_VAR=I35)")
+}
+
+# The motion stop active readback status value with interpreted levels.
+# Defaults appropriate for usual requirements.
+record(bi, "$(P)$(active_R=:MOTIONSTOP_ACTIVE):RBV") {
+  field(DESC, "$(P) $(active_DESC=mstop active) readback" )
+  field(INP,  "$(P)$(active_R=:MOTIONSTOP_ACTIVE):GET.AINP PP")
+  field(SCAN, "$(SCAN=5 second)")
+  field(ZNAM, "$(active_ZNAM=Not Active)")
+  field(ZSV,  "$(active_ZSV=MINOR)")
+  field(ONAM, "$(active_ONAM=Active)")
+  field(OSV,  "$(active_OSV=NO_ALARM)")
+}
+

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -40,7 +40,7 @@ const int pmacHardwarePower::PMAC_STATUS1_IN_POSITION = (0x1 << 11);
 const int pmacHardwarePower::PMAC_STATUS1_BLOCK_REQUEST = (0x1 << 9);
 const int pmacHardwarePower::PMAC_STATUS1_PHASED_MOTOR = (0x1 << 8);
 
-pmacHardwarePower::pmacHardwarePower() : pmacDebugger("pmacHardwareTurbo") {
+pmacHardwarePower::pmacHardwarePower() : pmacDebugger("pmacHardwarePower") {
 }
 
 pmacHardwarePower::~pmacHardwarePower() {
@@ -116,6 +116,7 @@ pmacHardwarePower::parseAxisStatus(int axis, pmacCommandStore *sPtr, axisStatus 
   std::string csString = "";
   char var[16];
   static const char *functionName = "parseAxisStatus";
+  char msg[47];
 
   statusString = sPtr->readValue(this->getAxisStatusCmd(axis));
 
@@ -124,7 +125,8 @@ pmacHardwarePower::parseAxisStatus(int axis, pmacCommandStore *sPtr, axisStatus 
   nvals = sscanf(statusString.c_str(), " $%8x%8x", &axStatus.status24Bit1_,
                  &axStatus.status24Bit2_);
   if (nvals != 2) {
-    debug(DEBUG_ERROR, functionName, "Failed to parse axis status (24 bit)", statusString);
+    sprintf(msg, "Failed to parse axis %d status (24 bit)", axis);
+    debug(DEBUG_ERROR, functionName, msg, statusString);
     axStatus.status24Bit1_ = 0;
     axStatus.status24Bit2_ = 0;
     status = asynError;
@@ -132,7 +134,8 @@ pmacHardwarePower::parseAxisStatus(int axis, pmacCommandStore *sPtr, axisStatus 
   nvals = sscanf(statusString.c_str(), " $%4x%4x%4x%4x", &axStatus.status16Bit1_,
                  &axStatus.status16Bit2_, &axStatus.status16Bit3_, &dummyVal);
   if (nvals != 4) {
-    debug(DEBUG_ERROR, functionName, "Failed to parse axis status (16 bit)", statusString);
+    sprintf(msg, "Failed to parse axis %d status (16 bit)", axis);
+    debug(DEBUG_ERROR, functionName, msg, statusString);
     axStatus.status16Bit1_ = 0;
     axStatus.status16Bit2_ = 0;
     axStatus.status16Bit3_ = 0;


### PR DESCRIPTION
Changed maximum number of axes in builder PowerPMAC from 32 to 256.
Corrected name in power pmac debugging messages (from turbo to
power) and added axis number to axis status debug message.
