### PR TITLE
Add velocity array support for trajectories scan

### DIFF
--- a/pmacApp/Db/pmacControllerTrajectory.template
+++ b/pmacApp/Db/pmacControllerTrajectory.template
@@ -169,6 +169,32 @@ record(waveform,"$(PMAC):UserArray") {
     field(PREC, "3")
 }
 
+##
+## Records to set the velocity type for the trajectory scan
+## MODE => An array of velocity mode is used for velocity calculation on the pmac
+## ARRAY => An array of velocity values is supplied
+##
+record(bo, "$(PMAC):ProfileVelType")
+{
+  field(DESC, "Time mode for trajectory scan")
+  field(DTYP, "asynInt32")
+  field(OUT,  "@asyn($(PORT),0)PMAC_TRAJ_VELTYPE")
+  field(ZNAM, "MODE")
+  field(ONAM, "ARRAY")
+  field(VAL,  "0")
+  field(PINI, "YES")
+}
+
+record(bi, "$(PMAC):ProfileVelType_RBV")
+{
+  field(DESC, "Time mode for trajectory scan")
+  field(DTYP, "asynInt32")
+  field(INP,  "@asyn($(PORT),0)PMAC_TRAJ_VELTYPE")
+  field(ZNAM, "MODE")
+  field(ONAM, "ARRAY")
+  field(SCAN, "I/O Intr")  
+}
+
 ## Record to specific the Velocity mode to use at each point
 record(waveform,"$(PMAC):VelocityMode") {
     field(DESC, "Velocity mode at each point")
@@ -547,6 +573,17 @@ record(waveform,"$(PMAC):A:Positions") {
     field(PINI, "YES")
 }
 
+# Target velocity array for this axis
+record(waveform,"$(PMAC):A:Velocities") {
+    field(DESC, "Axis A velocities")
+    field(DTYP, "asynFloat64ArrayOut")
+    field(INP,  "@asyn($(PORT),0)PROFILE_VELOCITIES_A")
+    field(NELM, "$(NPOINTS)")
+    field(FTVL, "DOUBLE")
+    field(PREC, "$(PREC=3)")
+    field(PINI, "YES")
+}
+
 record(longout,"$(PMAC):A:NoOfPts") {
     field(DESC, "Axis A Qty Points")
     field(SCAN, "1 second")
@@ -574,6 +611,17 @@ record(waveform,"$(PMAC):B:Positions") {
     field(DESC, "Axis B positions")
     field(DTYP, "asynFloat64ArrayOut")
     field(INP,  "@asyn($(PORT),0)PROFILE_POSITIONS_B")
+    field(NELM, "$(NPOINTS)")
+    field(FTVL, "DOUBLE")
+    field(PREC, "$(PREC=3)")
+    field(PINI, "YES")
+}
+
+# Target velocity array for this axis
+record(waveform,"$(PMAC):B:Velocities") {
+    field(DESC, "Axis B velocities")
+    field(DTYP, "asynFloat64ArrayOut")
+    field(INP,  "@asyn($(PORT),0)PROFILE_VELOCITIES_B")
     field(NELM, "$(NPOINTS)")
     field(FTVL, "DOUBLE")
     field(PREC, "$(PREC=3)")
@@ -614,6 +662,17 @@ record(waveform,"$(PMAC):C:Positions") {
     field(PINI, "YES")
 }
 
+# Target velocity array for this axis
+record(waveform,"$(PMAC):C:Velocities") {
+    field(DESC, "Axis C velocities")
+    field(DTYP, "asynFloat64ArrayOut")
+    field(INP,  "@asyn($(PORT),0)PROFILE_VELOCITIES_C")
+    field(NELM, "$(NPOINTS)")
+    field(FTVL, "DOUBLE")
+    field(PREC, "$(PREC=3)")
+    field(PINI, "YES")
+}
+
 record(longout,"$(PMAC):C:NoOfPts") {
     field(DESC, "Axis C Qty Points")
     field(SCAN, "1 second")
@@ -642,6 +701,17 @@ record(waveform,"$(PMAC):U:Positions") {
     field(DESC, "Axis U positions")
     field(DTYP, "asynFloat64ArrayOut")
     field(INP,  "@asyn($(PORT),0)PROFILE_POSITIONS_U")
+    field(NELM, "$(NPOINTS)")
+    field(FTVL, "DOUBLE")
+    field(PREC, "$(PREC=3)")
+    field(PINI, "YES")
+}
+
+# Target velocity array for this axis
+record(waveform,"$(PMAC):U:Velocities") {
+    field(DESC, "Axis U velocities")
+    field(DTYP, "asynFloat64ArrayOut")
+    field(INP,  "@asyn($(PORT),0)PROFILE_VELOCITIES_U")
     field(NELM, "$(NPOINTS)")
     field(FTVL, "DOUBLE")
     field(PREC, "$(PREC=3)")
@@ -682,6 +752,17 @@ record(waveform,"$(PMAC):V:Positions") {
     field(PINI, "YES")
 }
 
+# Target velocity array for this axis
+record(waveform,"$(PMAC):V:Velocities") {
+    field(DESC, "Axis V velocities")
+    field(DTYP, "asynFloat64ArrayOut")
+    field(INP,  "@asyn($(PORT),0)PROFILE_VELOCITIES_V")
+    field(NELM, "$(NPOINTS)")
+    field(FTVL, "DOUBLE")
+    field(PREC, "$(PREC=3)")
+    field(PINI, "YES")
+}
+
 record(longout,"$(PMAC):V:NoOfPts") {
     field(DESC, "Axis V Qty Points")
     field(SCAN, "1 second")
@@ -709,6 +790,17 @@ record(waveform,"$(PMAC):W:Positions") {
     field(DESC, "Axis W positions")
     field(DTYP, "asynFloat64ArrayOut")
     field(INP,  "@asyn($(PORT),0)PROFILE_POSITIONS_W")
+    field(NELM, "$(NPOINTS)")
+    field(FTVL, "DOUBLE")
+    field(PREC, "$(PREC=3)")
+    field(PINI, "YES")
+}
+
+# Target velocity array for this axis
+record(waveform,"$(PMAC):W:Velocities") {
+    field(DESC, "Axis W velocities")
+    field(DTYP, "asynFloat64ArrayOut")
+    field(INP,  "@asyn($(PORT),0)PROFILE_VELOCITIES_W")
     field(NELM, "$(NPOINTS)")
     field(FTVL, "DOUBLE")
     field(PREC, "$(PREC=3)")
@@ -748,6 +840,17 @@ record(waveform,"$(PMAC):X:Positions") {
     field(PINI, "YES")
 }
 
+# Target velocity array for this axis
+record(waveform,"$(PMAC):X:Velocities") {
+    field(DESC, "Axis X velocities")
+    field(DTYP, "asynFloat64ArrayOut")
+    field(INP,  "@asyn($(PORT),0)PROFILE_VELOCITIES_X")
+    field(NELM, "$(NPOINTS)")
+    field(FTVL, "DOUBLE")
+    field(PREC, "$(PREC=3)")
+    field(PINI, "YES")
+}
+
 record(longout,"$(PMAC):X:NoOfPts") {
     field(DESC, "Axis X Qty Points")
     field(SCAN, "1 second")
@@ -781,6 +884,17 @@ record(waveform,"$(PMAC):Y:Positions") {
     field(PINI, "YES")
 }
 
+# Target velocity array for this axis
+record(waveform,"$(PMAC):Y:Velocities") {
+    field(DESC, "Axis Y velocities")
+    field(DTYP, "asynFloat64ArrayOut")
+    field(INP,  "@asyn($(PORT),0)PROFILE_VELOCITIES_Y")
+    field(NELM, "$(NPOINTS)")
+    field(FTVL, "DOUBLE")
+    field(PREC, "$(PREC=3)")
+    field(PINI, "YES")
+}
+
 record(longout,"$(PMAC):Y:NoOfPts") {
     field(DESC, "Axis Y Qty Points")
     field(SCAN, "1 second")
@@ -808,6 +922,17 @@ record(waveform,"$(PMAC):Z:Positions") {
     field(DESC, "Axis Z positions")
     field(DTYP, "asynFloat64ArrayOut")
     field(INP,  "@asyn($(PORT),0)PROFILE_POSITIONS_Z")
+    field(NELM, "$(NPOINTS)")
+    field(FTVL, "DOUBLE")
+    field(PREC, "$(PREC=3)")
+    field(PINI, "YES")
+}
+
+# Target velocity array for this axis
+record(waveform,"$(PMAC):Z:Velocities") {
+    field(DESC, "Axis Z velocities")
+    field(DTYP, "asynFloat64ArrayOut")
+    field(INP,  "@asyn($(PORT),0)PROFILE_VELOCITIES_Z")
     field(NELM, "$(NPOINTS)")
     field(FTVL, "DOUBLE")
     field(PREC, "$(PREC=3)")

--- a/pmacApp/Db/pmacControllerTrajectory.template
+++ b/pmacApp/Db/pmacControllerTrajectory.template
@@ -181,8 +181,6 @@ record(bo, "$(PMAC):ProfileCalcVel")
   field(OUT,  "@asyn($(PORT),0)PMAC_TRAJ_CALCVEL")
   field(ZNAM, "NO")
   field(ONAM, "YES")
-  field(VAL,  "1")
-  field(PINI, "YES")
 }
 
 record(bi, "$(PMAC):ProfileCalcVel_RBV")

--- a/pmacApp/Db/pmacControllerTrajectory.template
+++ b/pmacApp/Db/pmacControllerTrajectory.template
@@ -170,29 +170,29 @@ record(waveform,"$(PMAC):UserArray") {
 }
 
 ##
-## Records to set the velocity type for the trajectory scan
-## MODE => An array of velocity mode is used for velocity calculation on the pmac
-## ARRAY => An array of velocity values is supplied
+## Records to set the velocities calculation
+## NO => The velocities arrays are supplied
+## YES => The velocities arrays are calculated using the VelocityMode
 ##
-record(bo, "$(PMAC):ProfileVelType")
+record(bo, "$(PMAC):ProfileCalcVel")
 {
-  field(DESC, "Time mode for trajectory scan")
+  field(DESC, "Calculate the velocities arrays")
   field(DTYP, "asynInt32")
-  field(OUT,  "@asyn($(PORT),0)PMAC_TRAJ_VELTYPE")
-  field(ZNAM, "MODE")
-  field(ONAM, "ARRAY")
-  field(VAL,  "0")
+  field(OUT,  "@asyn($(PORT),0)PMAC_TRAJ_CALCVEL")
+  field(ZNAM, "NO")
+  field(ONAM, "YES")
+  field(VAL,  "1")
   field(PINI, "YES")
 }
 
-record(bi, "$(PMAC):ProfileVelType_RBV")
+record(bi, "$(PMAC):ProfileCalcVel_RBV")
 {
-  field(DESC, "Time mode for trajectory scan")
+  field(DESC, "Calculate the velocities arrays")
   field(DTYP, "asynInt32")
-  field(INP,  "@asyn($(PORT),0)PMAC_TRAJ_VELTYPE")
-  field(ZNAM, "MODE")
-  field(ONAM, "ARRAY")
-  field(SCAN, "I/O Intr")  
+  field(INP,  "@asyn($(PORT),0)PMAC_TRAJ_CALCVEL")
+  field(ZNAM, "NO")
+  field(ONAM, "YES")
+  field(SCAN, "I/O Intr")
 }
 
 ## Record to specific the Velocity mode to use at each point

--- a/pmacApp/pmc/trajectory_scan_clipper.pmc
+++ b/pmacApp/pmc/trajectory_scan_clipper.pmc
@@ -2,7 +2,7 @@
 ; Set these values for your PMAC
 ; *****************************************************************************************
 #define VarAdr       B8     ; Prefix of address (eg VarAdr=300 then $30000 is the start address)
-#define BuffLen      950    ; Length of buffers
+#define BuffLen      500    ; Length of buffers
 #define MoveRoutine  111    ; The subroutine for movement (default 111), can be overridden for custom scan moves
 
 ; make sure the ubuffer is defined

--- a/pmacApp/pmc/trajectory_scan_code.pmc
+++ b/pmacApp/pmc/trajectory_scan_code.pmc
@@ -7,7 +7,7 @@ Del Gat
 ; Set Initial Values
 BufferLength = BuffLen                          ; BuffLen defined in header file
 BufferAdr_A = $BufferAdr                        ; BufferAdr defined in header file
-BufferAdr_B = BufferAdr_A + 10*BufferLength
+BufferAdr_B = BufferAdr_A + 19*BufferLength
 Status = 0
 Abort = 0
 Error = 0
@@ -40,7 +40,6 @@ PrevBufferFill = BufferLength       ; Set PrevBufferFill to pass outer while loo
 GoSub101                            ; Check which axes are required
 GoSub103                            ; Set addresses for required axes
 GoSub108                            ; set all previous velocities to zero
-GoSub112                            ; initialize previous positions
 
 While(Abort = 0 and Error = 0 and CurrentBufferFill > 0 and PrevBufferFill = BufferLength)
 
@@ -49,7 +48,7 @@ While(Abort = 0 and Error = 0 and CurrentBufferFill > 0 and PrevBufferFill = Buf
     While(Abort = 0 and Error = 0 and CurrentIndex < CurrentBufferFill)
 
         GoSub102                            ; Shift values through Next_* -> Current_* -> Prev_*
-        GoSub104                            ; Calculate velocities
+        GoSub104                            ; Check time
         GoSub110                            ; Move axes
         CurrentIndex = CurrentIndex + 1
 
@@ -76,7 +75,7 @@ While(Abort = 0 and Error = 0 and CurrentBufferFill > 0 and PrevBufferFill = Buf
 
             CurrentIndex = 0                    ; Reset to start of next buffer
             GoSub103                            ; Update Next_* addresses to 0th point of next buffer
-            GoSub104                            ; Calculate velocities
+            GoSub104                            ; Check time
             GoSub110                            ; Move axes to final point of previous buffer
         Else
             ; Move to final point if the scan wasn't aborted
@@ -124,67 +123,64 @@ Return
 N102
     Time = Next_Time
     User = Next_User
-    VelMode = NextVelMode
     CalculatedBase = CurrentBufferAdr + CurrentIndex
     Time_Adr = CalculatedBase
     User_Adr = CalculatedBase
-    VelMode_Adr = CalculatedBase
 
 
     If(A_Axis = 1)
-        Prev_A = Current_A
         Current_A = Next_A
-        A_Prev_Vel = A_Vel
+        A_Vel = Next_A_Vel
     End If
     A_Adr = CalculatedBase + BufferLength
+    A_Vel_Adr = Z_Adr + BufferLength
     If(B_Axis = 1)
-        Prev_B = Current_B
         Current_B = Next_B
-        B_Prev_Vel = B_Vel
+        B_Vel = Next_B_Vel
     End If
     B_Adr = A_Adr + BufferLength
+    B_Vel_Adr = A_Vel_Adr + BufferLength
     If (C_Axis = 1)
-        Prev_C = Current_C
         Current_C = Next_C
-        C_Prev_Vel = C_Vel
+        C_Vel = Next_C_Vel
     End If
     C_Adr = B_Adr + BufferLength
+    C_Vel_Adr = B_Vel_Adr + BufferLength
     If (U_Axis = 1)
-        Prev_U = Current_U
         Current_U = Next_U
-        U_Prev_Vel = U_Vel
+        U_Vel = Next_U_Vel
     End If
     U_Adr = C_Adr + BufferLength
+    U_Vel_Adr = C_Vel_Adr + BufferLength
     If (V_Axis = 1)
-        Prev_V = Current_V
         Current_V = Next_V
-        V_Prev_Vel = V_Vel
+        V_Vel = Next_V_Vel
     End If
     V_Adr = U_Adr + BufferLength
+    V_Vel_Adr = U_Vel_Adr + BufferLength
     If (W_Axis = 1)
-        Prev_W = Current_W
         Current_W = Next_W
-        W_Prev_Vel = W_Vel
+        W_Vel = Next_W_Vel
     End If
     W_Adr = V_Adr + BufferLength
     If (X_Axis = 1)
-        Prev_X = Current_X
         Current_X = Next_X
-        X_Prev_Vel = X_Vel
+        X_Vel = Next_X_Vel
     End If
     X_Adr = W_Adr + BufferLength
+    X_Vel_Adr = W_Vel_Adr + BufferLength
     If (Y_Axis = 1)
-        Prev_Y = Current_Y
         Current_Y = Next_Y
-        Y_Prev_Vel = Y_Vel
+        Y_Vel = Next_Y_Vel
     End If
     Y_Adr = X_Adr + BufferLength
+    Y_Vel_Adr = X_Vel_Adr + BufferLength
     If (Z_Axis = 1)
-        Prev_Z = Current_Z
         Current_Z = Next_Z
-        Z_Prev_Vel = Z_Vel
+        Z_Vel = Next_Z_Vel
     End If
     Z_Adr = Y_Adr + BufferLength
+    Z_Vel_Adr = Y_Vel_Adr + BufferLength
 Return
 
 ; Subroutine 3 ************************************************************************************
@@ -198,7 +194,6 @@ N103
     CalculatedBase = CurrentBufferAdr + CurrentIndex
     Time_Adr = CalculatedBase
     User_Adr = CalculatedBase
-    VelMode_Adr = CalculatedBase
     A_Adr = CalculatedBase + BufferLength
     B_Adr = A_Adr + BufferLength
     C_Adr = B_Adr + BufferLength
@@ -208,13 +203,20 @@ N103
     X_Adr = W_Adr + BufferLength
     Y_Adr = X_Adr + BufferLength
     Z_Adr = Y_Adr + BufferLength
+    A_Vel_Adr = Z_Adr + BufferLength
+    B_Vel_Adr = A_Vel_Adr + BufferLength 
+    C_Vel_Adr = B_Vel_Adr + BufferLength
+    U_Vel_Adr = C_Vel_Adr + BufferLength
+    V_Vel_Adr = U_Vel_Adr + BufferLength
+    W_Vel_Adr = V_Vel_Adr + BufferLength
+    X_Vel_Adr = W_Vel_Adr + BufferLength
+    Y_Vel_Adr = X_Vel_Adr + BufferLength
+    Z_Vel_Adr = Y_Vel_Adr + BufferLength
+    
 Return
 
-; Subroutines 4-8 *********************************************************************************
-; Calculate velocities for next move - 4: Master, 5: Prev->Current, 6: Prev->Next, 7: Current->Next
-; 8: Zero velocity for final move
-; Velocities are multiplied by 1000000 because the units of Time are microseconds and the units
-; of velocity are EGUs/second in the PVT move definition
+; Subroutines 4 *********************************************************************************
+; Check time value for the next movement and set error if it is zero
 ; *************************************************************************************************
 
 N104
@@ -226,62 +228,7 @@ N104
         Time = 1000
     End If
 
-    ; Select velocity calculation based on VelMode value
-    If(VelMode = 1)
-        GoSub105                        ; Real Prev -> Current
-    EndIf
-    If(VelMode = 0)
-        GoSub106                        ; Average Prev -> Next
-    EndIf
-    If(VelMode = 2)
-        GoSub107                        ; Average Prev -> Current
-    EndIf
-    If(VelMode = 3)
-        GoSub108			            ; Zero
-    EndIf
-    If(VelMode = 4)
-        GoSub109			            ; Average Current -> Next
-    EndIf
-Return
 
-N105 ; Real Prev -> Current
-    InverseTmpTime = 1000000/Time
-    A_Vel = A_Axis*((2.0*(Current_A - Prev_A) * InverseTmpTime) - A_Prev_Vel)
-    B_Vel = B_Axis*((2.0*(Current_B - Prev_B) * InverseTmpTime) - B_Prev_Vel)
-    C_Vel = C_Axis*((2.0*(Current_C - Prev_C) * InverseTmpTime) - C_Prev_Vel)
-    U_Vel = U_Axis*((2.0*(Current_U - Prev_U) * InverseTmpTime) - U_Prev_Vel)
-    V_Vel = V_Axis*((2.0*(Current_V - Prev_V) * InverseTmpTime) - V_Prev_Vel)
-    W_Vel = W_Axis*((2.0*(Current_W - Prev_W) * InverseTmpTime) - W_Prev_Vel)
-    X_Vel = X_Axis*((2.0*(Current_X - Prev_X) * InverseTmpTime) - X_Prev_Vel)
-    Y_Vel = Y_Axis*((2.0*(Current_Y - Prev_Y) * InverseTmpTime) - Y_Prev_Vel)
-    Z_Vel = Z_Axis*((2.0*(Current_Z - Prev_Z) * InverseTmpTime) - Z_Prev_Vel)
-Return
-
-N106 ; Average Prev -> Next
-    InverseTmpTime = 1000000/(Time + Next_Time)
-    A_Vel = A_Axis*InverseTmpTime*(Next_A - Prev_A)
-    B_Vel = B_Axis*InverseTmpTime*(Next_B - Prev_B)
-    C_Vel = C_Axis*InverseTmpTime*(Next_C - Prev_C)
-    U_Vel = U_Axis*InverseTmpTime*(Next_U - Prev_U)
-    V_Vel = V_Axis*InverseTmpTime*(Next_V - Prev_V)
-    W_Vel = W_Axis*InverseTmpTime*(Next_W - Prev_W)
-    X_Vel = X_Axis*InverseTmpTime*(Next_X - Prev_X)
-    Y_Vel = Y_Axis*InverseTmpTime*(Next_Y - Prev_Y)
-    Z_Vel = Z_Axis*InverseTmpTime*(Next_Z - Prev_Z)
-Return
-
-N107 ; Average Prev -> Current
-    InverseTmpTime = 1000000/Time
-    A_Vel = A_Axis*InverseTmpTime*(Current_A - Prev_A)
-    B_Vel = B_Axis*InverseTmpTime*(Current_B - Prev_B)
-    C_Vel = C_Axis*InverseTmpTime*(Current_C - Prev_C)
-    U_Vel = U_Axis*InverseTmpTime*(Current_U - Prev_U)
-    V_Vel = V_Axis*InverseTmpTime*(Current_V - Prev_V)
-    W_Vel = W_Axis*InverseTmpTime*(Current_W - Prev_W)
-    X_Vel = X_Axis*InverseTmpTime*(Current_X - Prev_X)
-    Y_Vel = Y_Axis*InverseTmpTime*(Current_Y - Prev_Y)
-    Z_Vel = Z_Axis*InverseTmpTime*(Current_Z - Prev_Z)
-Return
 
 N108 ; Zero
     A_Vel = 0
@@ -293,19 +240,6 @@ N108 ; Zero
     X_Vel = 0
     Y_Vel = 0
     Z_Vel = 0
-Return
-
-N109 ; Average Current -> Next
-    InverseTmpTime = 1000000/Next_Time
-    A_Vel = A_Axis*InverseTmpTime*(Next_A - Current_A)
-    B_Vel = B_Axis*InverseTmpTime*(Next_B - Current_B)
-    C_Vel = C_Axis*InverseTmpTime*(Next_C - Current_C)
-    U_Vel = U_Axis*InverseTmpTime*(Next_U - Current_U)
-    V_Vel = V_Axis*InverseTmpTime*(Next_V - Current_V)
-    W_Vel = W_Axis*InverseTmpTime*(Next_W - Current_W)
-    X_Vel = X_Axis*InverseTmpTime*(Next_X - Current_X)
-    Y_Vel = Y_Axis*InverseTmpTime*(Next_Y - Current_Y)
-    Z_Vel = Z_Axis*InverseTmpTime*(Next_Z - Current_Z)
 Return
 
 
@@ -330,17 +264,6 @@ N111
     A(Current_A):(A_Vel) B(Current_B):(B_Vel) C(Current_C):(C_Vel) U(Current_U):(U_Vel) V(Current_V):(V_Vel) W(Current_W):(W_Vel) X(Current_X):(X_Vel) Y(Current_Y):(Y_Vel) Z(Current_Z):(Z_Vel)
 Return
 
-N112 ; set previous positions to the starting position of the motors
-    Prev_A = Current_A
-    Prev_B = Current_B
-    Prev_C = Current_C
-    Prev_U = Current_U
-    Prev_V = Current_V
-    Prev_W = Current_W
-    Prev_X = Current_X
-    Prev_Y = Current_Y
-    Prev_Z = Current_Z
-Return
 
 
 ; User Subroutines ********************************************************************************

--- a/pmacApp/pmc/trajectory_scan_code.pmc
+++ b/pmacApp/pmc/trajectory_scan_code.pmc
@@ -228,7 +228,7 @@ N104
         Dwell 0
         Time = 1000
     End If
-
+Return
 
 
 N108 ; Zero

--- a/pmacApp/pmc/trajectory_scan_code.pmc
+++ b/pmacApp/pmc/trajectory_scan_code.pmc
@@ -163,6 +163,7 @@ N102
         W_Vel = Next_W_Vel
     End If
     W_Adr = V_Adr + BufferLength
+    W_Vel_Adr = V_Vel_Adr + BufferLength
     If (X_Axis = 1)
         Current_X = Next_X
         X_Vel = Next_X_Vel

--- a/pmacApp/pmc/trajectory_scan_code.pmc
+++ b/pmacApp/pmc/trajectory_scan_code.pmc
@@ -205,7 +205,7 @@ N103
     Y_Adr = X_Adr + BufferLength
     Z_Adr = Y_Adr + BufferLength
     A_Vel_Adr = Z_Adr + BufferLength
-    B_Vel_Adr = A_Vel_Adr + BufferLength 
+    B_Vel_Adr = A_Vel_Adr + BufferLength
     C_Vel_Adr = B_Vel_Adr + BufferLength
     U_Vel_Adr = C_Vel_Adr + BufferLength
     V_Vel_Adr = U_Vel_Adr + BufferLength
@@ -213,7 +213,7 @@ N103
     X_Vel_Adr = W_Vel_Adr + BufferLength
     Y_Vel_Adr = X_Vel_Adr + BufferLength
     Z_Vel_Adr = Y_Vel_Adr + BufferLength
-    
+
 Return
 
 ; Subroutines 4 *********************************************************************************

--- a/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
+++ b/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
@@ -163,7 +163,7 @@ N102:
     If (W_Axis == 1)
     {
         Current_W = Next_W(CalculatedBase)
-        V_Vel = Next_V_Vel(CalculatedBase)
+        W_Vel = Next_W_Vel(CalculatedBase)
     }
     If (X_Axis == 1)
     {

--- a/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
+++ b/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
@@ -43,7 +43,7 @@ While(AbortTrigger == 0 && Error == 0 && CurrentBufferFill > 0 && PrevBufferFill
     While(AbortTrigger == 0 && Error == 0 && CurrentIndex < CurrentBufferFill)
     {
         GoSub102                            // Shift values through Next_* -> Current_* -> Prev_*
-        GoSub104                            // Calculate velocities
+        GoSub104                            // Check time
         GoSub110                            // Move axes
         CurrentIndex = CurrentIndex + 1
 
@@ -74,7 +74,7 @@ While(AbortTrigger == 0 && Error == 0 && CurrentBufferFill > 0 && PrevBufferFill
         {
             CurrentIndex = 0                    // Reset to start of next buffer
             GoSub103                            // Update Next_* addresses to 0th point of next buffer
-            GoSub104                            // Calculate velocities
+            GoSub104                            // Check time
             GoSub110                            // Move axes to final point of previous buffer
         }
         Else
@@ -137,57 +137,48 @@ N102:
 
     If(A_Axis == 1)
     {
-        Prev_A = Current_A
         Current_A = Next_A(CalculatedBase)
-        A_Prev_Vel = A_Vel
+        A_Vel = Next_A_Vel(CalculatedBase)
     }
     If (B_Axis == 1)
     {
-        Prev_B = Current_B
         Current_B = Next_B(CalculatedBase)
-        B_Prev_Vel = B_Vel
+        B_Vel = Next_B_Vel(CalculatedBase)
     }
     If (C_Axis == 1)
     {
-        Prev_C = Current_C
         Current_C = Next_C(CalculatedBase)
-        C_Prev_Vel = C_Vel
+        C_Vel = Next_C_Vel(CalculatedBase)
     }
     If (U_Axis == 1)
     {
-        Prev_U = Current_U
         Current_U = Next_U(CalculatedBase)
-        U_Prev_Vel = U_Vel
+        U_Vel = Next_U_Vel(CalculatedBase)
     }
     If (V_Axis == 1)
     {
-        Prev_V = Current_V
         Current_V = Next_V(CalculatedBase)
-        V_Prev_Vel = V_Vel
+        V_Vel = Next_V_Vel(CalculatedBase)
     }
     If (W_Axis == 1)
     {
-        Prev_W = Current_W
         Current_W = Next_W(CalculatedBase)
-        W_Prev_Vel = W_Vel
+        V_Vel = Next_V_Vel(CalculatedBase)
     }
     If (X_Axis == 1)
     {
-        Prev_X = Current_X
         Current_X = Next_X(CalculatedBase)
-        X_Prev_Vel = X_Vel
+        X_Vel = Next_X_Vel(CalculatedBase)
     }
     If (Y_Axis == 1)
     {
-        Prev_Y = Current_Y
         Current_Y = Next_Y(CalculatedBase)
-        Y_Prev_Vel = Y_Vel
+        Y_Vel = Next_Y_Vel(CalculatedBase)
     }
     If (Z_Axis == 1)
     {
-        Prev_Z = Current_Z
         Current_Z = Next_Z(CalculatedBase)
-        Z_Prev_Vel = Z_Vel
+        Z_Vel = Next_Z_Vel(CalculatedBase)
     }
 
     // All Prev <- Current <- Next shifts done so now
@@ -225,67 +216,10 @@ N104:
         Time = 1000
     }
 
-    // Select velocity calculation based on VelMode value
-    If(VelMode == 1)
-    {
-        GoSub105                        // Real Prev -> Current
-    }
-    If(VelMode == 0)
-    {
-        GoSub106                        // Average Prev -> Next
-    }
-    If(VelMode == 2)
-    {
-        GoSub107                        //  Average Prev -> Current
-    }
-    If(VelMode == 3)
-    {
-        GoSub108			            // Zero
-    }
-    If(VelMode == 4)
-    {
-        GoSub109			            // Average Current -> Next
-    }
+
 Return
 
-N105: // Real Prev -> Current
-    InverseTmpTime = 1000000/Time
-    A_Vel = A_Axis*((2.0*(Current_A - Prev_A) * InverseTmpTime) - A_Prev_Vel)
-    B_Vel = B_Axis*((2.0*(Current_B - Prev_B) * InverseTmpTime) - B_Prev_Vel)
-    C_Vel = C_Axis*((2.0*(Current_C - Prev_C) * InverseTmpTime) - C_Prev_Vel)
-    U_Vel = U_Axis*((2.0*(Current_U - Prev_U) * InverseTmpTime) - U_Prev_Vel)
-    V_Vel = V_Axis*((2.0*(Current_V - Prev_V) * InverseTmpTime) - V_Prev_Vel)
-    W_Vel = W_Axis*((2.0*(Current_W - Prev_W) * InverseTmpTime) - W_Prev_Vel)
-    X_Vel = X_Axis*((2.0*(Current_X - Prev_X) * InverseTmpTime) - X_Prev_Vel)
-    Y_Vel = Y_Axis*((2.0*(Current_Y - Prev_Y) * InverseTmpTime) - Y_Prev_Vel)
-    Z_Vel = Z_Axis*((2.0*(Current_Z - Prev_Z) * InverseTmpTime) - Z_Prev_Vel)
-Return
 
-N106: // Average Prev -> Next
-    InverseTmpTime = 1000000/(Time + Next_Time(CalculatedBase))
-    A_Vel = A_Axis*InverseTmpTime*(Next_A(CalculatedBase) - Prev_A)
-    B_Vel = B_Axis*InverseTmpTime*(Next_B(CalculatedBase) - Prev_B)
-    C_Vel = C_Axis*InverseTmpTime*(Next_C(CalculatedBase) - Prev_C)
-    U_Vel = U_Axis*InverseTmpTime*(Next_U(CalculatedBase) - Prev_U)
-    V_Vel = V_Axis*InverseTmpTime*(Next_V(CalculatedBase) - Prev_V)
-    W_Vel = W_Axis*InverseTmpTime*(Next_W(CalculatedBase) - Prev_W)
-    X_Vel = X_Axis*InverseTmpTime*(Next_X(CalculatedBase) - Prev_X)
-    Y_Vel = Y_Axis*InverseTmpTime*(Next_Y(CalculatedBase) - Prev_Y)
-    Z_Vel = Z_Axis*InverseTmpTime*(Next_Z(CalculatedBase) - Prev_Z)
-Return
-
-N107: // Average Prev -> Current
-    InverseTmpTime = 1000000/Next_Time(CalculatedBase)
-    A_Vel = A_Axis*InverseTmpTime*(Current_A - Prev_A)
-    B_Vel = B_Axis*InverseTmpTime*(Current_B - Prev_B)
-    C_Vel = C_Axis*InverseTmpTime*(Current_C - Prev_C)
-    U_Vel = U_Axis*InverseTmpTime*(Current_U - Prev_U)
-    V_Vel = V_Axis*InverseTmpTime*(Current_V - Prev_V)
-    W_Vel = W_Axis*InverseTmpTime*(Current_W - Prev_W)
-    X_Vel = X_Axis*InverseTmpTime*(Current_X - Prev_X)
-    Y_Vel = Y_Axis*InverseTmpTime*(Current_Y - Prev_Y)
-    Z_Vel = Z_Axis*InverseTmpTime*(Current_Z - Prev_Z)
-Return
 
 N108: // Zero
     A_Vel = 0
@@ -299,18 +233,6 @@ N108: // Zero
     Z_Vel = 0
 Return
 
-N109: // Average Current -> Next
-    InverseTmpTime = 1000000/Next_Time(CalculatedBase)
-    A_Vel = A_Axis*InverseTmpTime*(Next_A(CalculatedBase) - Current_A)
-    B_Vel = B_Axis*InverseTmpTime*(Next_B(CalculatedBase) - Current_B)
-    C_Vel = C_Axis*InverseTmpTime*(Next_C(CalculatedBase) - Current_C)
-    U_Vel = U_Axis*InverseTmpTime*(Next_U(CalculatedBase) - Current_U)
-    V_Vel = V_Axis*InverseTmpTime*(Next_V(CalculatedBase) - Current_V)
-    W_Vel = W_Axis*InverseTmpTime*(Next_W(CalculatedBase) - Current_W)
-    X_Vel = X_Axis*InverseTmpTime*(Next_X(CalculatedBase) - Current_X)
-    Y_Vel = Y_Axis*InverseTmpTime*(Next_Y(CalculatedBase) - Current_Y)
-    Z_Vel = Z_Axis*InverseTmpTime*(Next_Z(CalculatedBase) - Current_Z)
-Return
 
 // Subroutine 9 ************************************************************************************
 // Move axes
@@ -331,17 +253,6 @@ N111:
     A(Current_A):(A_Vel) B(Current_B):(B_Vel) C(Current_C):(C_Vel) U(Current_U):(U_Vel) V(Current_V):(V_Vel) W(Current_W):(W_Vel) X(Current_X):(X_Vel) Y(Current_Y):(Y_Vel) Z(Current_Z):(Z_Vel)
 Return
 
-N112: // set previous positions to the starting position of the motors
-    Prev_A = Readback_A
-    Prev_B = Readback_B
-    Prev_C = Readback_C
-    Prev_U = Readback_U
-    Prev_V = Readback_V
-    Prev_W = Readback_W
-    Prev_X = Readback_X
-    Prev_Y = Readback_Y
-    Prev_Z = Readback_Z
-Return
 
 // User Subroutines ********************************************************************************
 // Subroutines to be used via the user buffer

--- a/pmacApp/pmc/trajectory_scan_definitions.pmc
+++ b/pmacApp/pmc/trajectory_scan_definitions.pmc
@@ -101,15 +101,15 @@ X_Adr->Y:$4FA7,0,24
 Y_Adr->Y:$4FA8,0,24
 Z_Adr->Y:$4FA9,0,24
 User_Adr->Y:$4FAA,0,24
-A_Vel_Adr->Y:$4FAC,0,24
-B_Vel_Adr->Y:$4FAD,0,24
-C_Vel_Adr->Y:$4FAE,0,24
-U_Vel_Adr->Y:$4FAF,0,24
-V_Vel_Adr->Y:$4FB0,0,24
-W_Vel_Adr->Y:$4FB1,0,24
-X_Vel_Adr->Y:$4FB2,0,24
-Y_Vel_Adr->Y:$4FB3,0,24
-Z_Vel_Adr->Y:$4FB4,0,24
+A_Vel_Adr->Y:$4FAB,0,24
+B_Vel_Adr->Y:$4FAC,0,24
+C_Vel_Adr->Y:$4FAD,0,24
+U_Vel_Adr->Y:$4FAE,0,24
+V_Vel_Adr->Y:$4FAF,0,24
+W_Vel_Adr->Y:$4FB0,0,24
+X_Vel_Adr->Y:$4FB1,0,24
+Y_Vel_Adr->Y:$4FB2,0,24
+Z_Vel_Adr->Y:$4FB3,0,24
 
 #define AxesParser          M4024                   ; Specifiers for what axes are activated
 #define A_Axis              M4025

--- a/pmacApp/pmc/trajectory_scan_definitions.pmc
+++ b/pmacApp/pmc/trajectory_scan_definitions.pmc
@@ -32,7 +32,7 @@
 #define Next_Y              M4008
 #define Next_Z              M4009
 #define Next_User           M4010
-; //#define NextVelMode         M4011
+
 #define Next_A_Vel          M4085
 #define Next_B_Vel          M4086
 #define Next_C_Vel          M4087
@@ -43,7 +43,7 @@
 #define Next_Y_Vel          M4092
 #define Next_Z_Vel          M4093
 
-; //NextVelMode->X:$BlankAdr0,4,4                        ; Set initial pointers and type
+
 Next_User->X:$BlankAdr0,0,4
 Next_Time->Y:$BlankAdr0,0,24
 
@@ -79,7 +79,7 @@ Next_Z_Vel->L:$BufferAdr
 #define Y_Adr               M4020
 #define Z_Adr               M4021
 #define User_Adr            M4022
-;//#define VelMode_Adr         M4023
+
 #define A_Vel_Adr           M4094
 #define B_Vel_Adr           M4095
 #define C_Vel_Adr           M4096
@@ -101,7 +101,6 @@ X_Adr->Y:$4FA7,0,24
 Y_Adr->Y:$4FA8,0,24
 Z_Adr->Y:$4FA9,0,24
 User_Adr->Y:$4FAA,0,24
-;//VelMode_Adr->Y:$4FAB,0,24
 A_Vel_Adr->Y:$4FAC,0,24
 B_Vel_Adr->Y:$4FAD,0,24
 C_Vel_Adr->Y:$4FAE,0,24
@@ -163,15 +162,6 @@ Z_Axis->Y:$AxisAdr,8
 ; *****************************************************************************************
 ; Motion Program Variables
 ; *****************************************************************************************
-; // #define Prev_A              M4050           ; Previous coordinates for velocity calculations
-; // #define Prev_B              M4051
-; // #define Prev_C              M4052
-; // #define Prev_U              M4053
-; // #define Prev_V              M4054
-; // #define Prev_W              M4055
-; // #define Prev_X              M4056
-; // #define Prev_Y              M4057
-; // #define Prev_Z              M4058
 
 #define Time                M4059           ; Current coordinate values
 #define Current_A           Q71
@@ -184,7 +174,6 @@ Z_Axis->Y:$AxisAdr,8
 #define Current_Y           Q78
 #define Current_Z           Q79
 #define User                M4060
-;//#define VelMode             M4061
 
 #define Readback_A           Q81
 #define Readback_B           Q82
@@ -206,20 +195,7 @@ Z_Axis->Y:$AxisAdr,8
 #define Y_Vel               M4069
 #define Z_Vel               M4070
 
-; // #define A_Prev_Vel          M4071          ; Previous velocity values
-; // #define B_Prev_Vel          M4072
-; // #define C_Prev_Vel          M4073
-; // #define U_Prev_Vel          M4074
-; // #define V_Prev_Vel          M4075
-; // #define W_Prev_Vel          M4076
-; // #define X_Prev_Vel          M4077
-; // #define Y_Prev_Vel          M4078
-; // #define Z_Prev_Vel          M4079
-
 #define CalculatedBase      M4081           ; Calculated temporary variable for Current base address
-;// #define InverseTmpTime      M4082           ; Calculated temporary variable for time in velocity calcs
-;// #define TmpVelX             M4083           ; Calculated temporary variable for velocity in velocity calcs
-;// #define TmpVelY             M4084
 
 ; *****************************************************************************************
 ; Progran variable assignments
@@ -240,18 +216,8 @@ CurrentBufferFill->Y:$VarAdr0C,0,24
 PrevBufferFill->Y:$VarAdr0D,0,24
 Error->Y:$VarAdr0E,0,24
 Version->* ; this is deliberately unmapped so that the value assigned survives a brick swap
-Prev_A->L:$VarAdr10
-Prev_B->L:$VarAdr11
-Prev_C->L:$VarAdr12
-Prev_U->L:$VarAdr13
-Prev_V->L:$VarAdr14
-Prev_W->L:$VarAdr15
-Prev_X->L:$VarAdr16
-Prev_Y->L:$VarAdr17
-Prev_Z->L:$VarAdr18
 Time->L:$VarAdr19
 User->L:$VarAdr1A
-;//VelMode->L:$VarAdr1B
 A_Vel->L:$VarAdr1C
 B_Vel->L:$VarAdr1D
 C_Vel->L:$VarAdr1E
@@ -261,19 +227,7 @@ W_Vel->L:$VarAdr21
 X_Vel->L:$VarAdr22
 Y_Vel->L:$VarAdr23
 Z_Vel->L:$VarAdr24
-;// A_Prev_Vel->L:$VarAdr25
-;// B_Prev_Vel->L:$VarAdr26
-;// C_Prev_Vel->L:$VarAdr27
-;// U_Prev_Vel->L:$VarAdr28
-;// V_Prev_Vel->L:$VarAdr29
-;// W_Prev_Vel->L:$VarAdr2A
-;// X_Prev_Vel->L:$VarAdr2B
-;// Y_Prev_Vel->L:$VarAdr2C
-;// Z_Prev_Vel->L:$VarAdr2D
 CalculatedBase->L:$VarAdr2E
-// InverseTmpTime->L:$VarAdr2E
-// TmpVelX->L:$VarAdr2F
-// TmpVelY->L:$VarAdr30
 
 
 ; *****************************************************************************************

--- a/pmacApp/pmc/trajectory_scan_definitions.pmc
+++ b/pmacApp/pmc/trajectory_scan_definitions.pmc
@@ -7,7 +7,7 @@
 ; Set these values for your PMAC
 ; *****************************************************************************************
 #define ProgramNum   1     ; Which motion program to use for scanning
-#define VersionNum   3     ; Must be an integer (because it is now stored in an unmapped M variable)
+#define VersionNum   4     ; Must be an integer (because it is now stored in an unmapped M variable)
 
 
 ; *****************************************************************************************
@@ -32,9 +32,18 @@
 #define Next_Y              M4008
 #define Next_Z              M4009
 #define Next_User           M4010
-#define NextVelMode         M4011
+; //#define NextVelMode         M4011
+#define Next_A_Vel          M4085
+#define Next_B_Vel          M4086
+#define Next_C_Vel          M4087
+#define Next_U_Vel          M4088
+#define Next_V_Vel          M4089
+#define Next_W_Vel          M4090
+#define Next_X_Vel          M4091
+#define Next_Y_Vel          M4092
+#define Next_Z_Vel          M4093
 
-NextVelMode->X:$BlankAdr0,4,4                        ; Set initial pointers and type
+; //NextVelMode->X:$BlankAdr0,4,4                        ; Set initial pointers and type
 Next_User->X:$BlankAdr0,0,4
 Next_Time->Y:$BlankAdr0,0,24
 
@@ -49,6 +58,16 @@ Next_X->L:$BufferAdr
 Next_Y->L:$BufferAdr
 Next_Z->L:$BufferAdr
 
+Next_A_Vel->L:$BufferAdr 
+Next_B_Vel->L:$BufferAdr
+Next_C_Vel->L:$BufferAdr
+Next_U_Vel->L:$BufferAdr
+Next_V_Vel->L:$BufferAdr
+Next_W_Vel->L:$BufferAdr
+Next_X_Vel->L:$BufferAdr
+Next_Y_Vel->L:$BufferAdr
+Next_Z_Vel->L:$BufferAdr
+
 #define Time_Adr            M4012                   ; Pointers to Next_* coordinate addresses
 #define A_Adr               M4013
 #define B_Adr               M4014
@@ -60,7 +79,16 @@ Next_Z->L:$BufferAdr
 #define Y_Adr               M4020
 #define Z_Adr               M4021
 #define User_Adr            M4022
-#define VelMode_Adr         M4023
+;//#define VelMode_Adr         M4023
+#define A_Vel_Adr           M4094
+#define B_Vel_Adr           M4095
+#define C_Vel_Adr           M4096
+#define U_Vel_Adr           M4097
+#define V_Vel_Adr           M4098
+#define W_Vel_Adr           M4099
+#define X_Vel_Adr           M4100
+#define Y_Vel_Adr           M4101
+#define Z_Vel_Adr           M4102
 
 Time_Adr->Y$4FA0,0,24                               ; Assignments for pointers to M address locations
 A_Adr->Y:$4FA1,0,24                                 ; M0 = $4000 -> M4000 = $4FA0
@@ -73,7 +101,16 @@ X_Adr->Y:$4FA7,0,24
 Y_Adr->Y:$4FA8,0,24
 Z_Adr->Y:$4FA9,0,24
 User_Adr->Y:$4FAA,0,24
-VelMode_Adr->Y:$4FAB,0,24
+;//VelMode_Adr->Y:$4FAB,0,24
+A_Vel_Adr->Y:$4FAC,0,24
+B_Vel_Adr->Y:$4FAD,0,24
+C_Vel_Adr->Y:$4FAE,0,24
+U_Vel_Adr->Y:$4FAF,0,24
+V_Vel_Adr->Y:$4FB0,0,24
+W_Vel_Adr->Y:$4FB1,0,24
+X_Vel_Adr->Y:$4FB2,0,24
+Y_Vel_Adr->Y:$4FB3,0,24
+Z_Vel_Adr->Y:$4FB4,0,24
 
 #define AxesParser          M4024                   ; Specifiers for what axes are activated
 #define A_Axis              M4025
@@ -126,15 +163,15 @@ Z_Axis->Y:$AxisAdr,8
 ; *****************************************************************************************
 ; Motion Program Variables
 ; *****************************************************************************************
-#define Prev_A              M4050           ; Previous coordinates for velocity calculations
-#define Prev_B              M4051
-#define Prev_C              M4052
-#define Prev_U              M4053
-#define Prev_V              M4054
-#define Prev_W              M4055
-#define Prev_X              M4056
-#define Prev_Y              M4057
-#define Prev_Z              M4058
+; // #define Prev_A              M4050           ; Previous coordinates for velocity calculations
+; // #define Prev_B              M4051
+; // #define Prev_C              M4052
+; // #define Prev_U              M4053
+; // #define Prev_V              M4054
+; // #define Prev_W              M4055
+; // #define Prev_X              M4056
+; // #define Prev_Y              M4057
+; // #define Prev_Z              M4058
 
 #define Time                M4059           ; Current coordinate values
 #define Current_A           Q71
@@ -147,7 +184,7 @@ Z_Axis->Y:$AxisAdr,8
 #define Current_Y           Q78
 #define Current_Z           Q79
 #define User                M4060
-#define VelMode             M4061
+;//#define VelMode             M4061
 
 #define Readback_A           Q81
 #define Readback_B           Q82
@@ -169,20 +206,20 @@ Z_Axis->Y:$AxisAdr,8
 #define Y_Vel               M4069
 #define Z_Vel               M4070
 
-#define A_Prev_Vel          M4071          ; Previous velocity values
-#define B_Prev_Vel          M4072
-#define C_Prev_Vel          M4073
-#define U_Prev_Vel          M4074
-#define V_Prev_Vel          M4075
-#define W_Prev_Vel          M4076
-#define X_Prev_Vel          M4077
-#define Y_Prev_Vel          M4078
-#define Z_Prev_Vel          M4079
+; // #define A_Prev_Vel          M4071          ; Previous velocity values
+; // #define B_Prev_Vel          M4072
+; // #define C_Prev_Vel          M4073
+; // #define U_Prev_Vel          M4074
+; // #define V_Prev_Vel          M4075
+; // #define W_Prev_Vel          M4076
+; // #define X_Prev_Vel          M4077
+; // #define Y_Prev_Vel          M4078
+; // #define Z_Prev_Vel          M4079
 
 #define CalculatedBase      M4081           ; Calculated temporary variable for Current base address
-#define InverseTmpTime      M4082           ; Calculated temporary variable for time in velocity calcs
-#define TmpVelX             M4083           ; Calculated temporary variable for velocity in velocity calcs
-#define TmpVelY             M4084
+;// #define InverseTmpTime      M4082           ; Calculated temporary variable for time in velocity calcs
+;// #define TmpVelX             M4083           ; Calculated temporary variable for velocity in velocity calcs
+;// #define TmpVelY             M4084
 
 ; *****************************************************************************************
 ; Progran variable assignments
@@ -214,7 +251,7 @@ Prev_Y->L:$VarAdr17
 Prev_Z->L:$VarAdr18
 Time->L:$VarAdr19
 User->L:$VarAdr1A
-VelMode->L:$VarAdr1B
+;//VelMode->L:$VarAdr1B
 A_Vel->L:$VarAdr1C
 B_Vel->L:$VarAdr1D
 C_Vel->L:$VarAdr1E
@@ -224,19 +261,19 @@ W_Vel->L:$VarAdr21
 X_Vel->L:$VarAdr22
 Y_Vel->L:$VarAdr23
 Z_Vel->L:$VarAdr24
-A_Prev_Vel->L:$VarAdr25
-B_Prev_Vel->L:$VarAdr26
-C_Prev_Vel->L:$VarAdr27
-U_Prev_Vel->L:$VarAdr28
-V_Prev_Vel->L:$VarAdr29
-W_Prev_Vel->L:$VarAdr2A
-X_Prev_Vel->L:$VarAdr2B
-Y_Prev_Vel->L:$VarAdr2C
-Z_Prev_Vel->L:$VarAdr2E
-CalculatedBase->L:$VarAdr2F
-InverseTmpTime->L:$VarAdr30
-TmpVelX->L:$VarAdr31
-TmpVelY->L:$VarAdr32
+;// A_Prev_Vel->L:$VarAdr25
+;// B_Prev_Vel->L:$VarAdr26
+;// C_Prev_Vel->L:$VarAdr27
+;// U_Prev_Vel->L:$VarAdr28
+;// V_Prev_Vel->L:$VarAdr29
+;// W_Prev_Vel->L:$VarAdr2A
+;// X_Prev_Vel->L:$VarAdr2B
+;// Y_Prev_Vel->L:$VarAdr2C
+;// Z_Prev_Vel->L:$VarAdr2D
+CalculatedBase->L:$VarAdr2E
+// InverseTmpTime->L:$VarAdr2E
+// TmpVelX->L:$VarAdr2F
+// TmpVelY->L:$VarAdr30
 
 
 ; *****************************************************************************************

--- a/pmacApp/pmc/trajectory_scan_definitions.pmc
+++ b/pmacApp/pmc/trajectory_scan_definitions.pmc
@@ -58,7 +58,7 @@ Next_X->L:$BufferAdr
 Next_Y->L:$BufferAdr
 Next_Z->L:$BufferAdr
 
-Next_A_Vel->L:$BufferAdr 
+Next_A_Vel->L:$BufferAdr
 Next_B_Vel->L:$BufferAdr
 Next_C_Vel->L:$BufferAdr
 Next_U_Vel->L:$BufferAdr
@@ -101,15 +101,15 @@ X_Adr->Y:$4FA7,0,24
 Y_Adr->Y:$4FA8,0,24
 Z_Adr->Y:$4FA9,0,24
 User_Adr->Y:$4FAA,0,24
-A_Vel_Adr->Y:$4FAB,0,24
-B_Vel_Adr->Y:$4FAC,0,24
-C_Vel_Adr->Y:$4FAD,0,24
-U_Vel_Adr->Y:$4FAE,0,24
-V_Vel_Adr->Y:$4FAF,0,24
-W_Vel_Adr->Y:$4FB0,0,24
-X_Vel_Adr->Y:$4FB1,0,24
-Y_Vel_Adr->Y:$4FB2,0,24
-Z_Vel_Adr->Y:$4FB3,0,24
+A_Vel_Adr->Y:$4FF5,0,24
+B_Vel_Adr->Y:$4FF6,0,24
+C_Vel_Adr->Y:$4FF7,0,24
+U_Vel_Adr->Y:$4FF8,0,24
+V_Vel_Adr->Y:$4FF9,0,24
+W_Vel_Adr->Y:$4FFA,0,24
+X_Vel_Adr->Y:$4FFB,0,24
+Y_Vel_Adr->Y:$4FFC,0,24
+Z_Vel_Adr->Y:$4FFD,0,24
 
 #define AxesParser          M4024                   ; Specifiers for what axes are activated
 #define A_Axis              M4025

--- a/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
+++ b/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
@@ -9,7 +9,7 @@
 // Set these values for your PMAC
 // *****************************************************************************************
 #define ProgramNum   1     // Which motion program to use for scanning
-#define VersionNum   3     // Version of this trajectory scan program
+#define VersionNum   4     // Version of this trajectory scan program
 
 // *****************************************************************************************
 // Address-Based Variables - on ppmac these are arrays and we index into all of them
@@ -25,8 +25,17 @@ global Next_W(DoubleBuffLen)
 global Next_X(DoubleBuffLen)
 global Next_Y(DoubleBuffLen)
 global Next_Z(DoubleBuffLen)
+global Next_A_Vel(DoubleBuffLen)
+global Next_B_Vel(DoubleBuffLen)
+global Next_C_Vel(DoubleBuffLen)
+global Next_U_Vel(DoubleBuffLen)
+global Next_V_Vel(DoubleBuffLen)
+global Next_W_Vel(DoubleBuffLen)
+global Next_X_Vel(DoubleBuffLen)
+global Next_Y_Vel(DoubleBuffLen)
+global Next_Z_Vel(DoubleBuffLen)
 global Next_User(DoubleBuffLen)
-global NextVelMode(DoubleBuffLen)
+//global NextVelMode(DoubleBuffLen)
 
 #define AxesParser          M4024                      // Specifiers for what axes are activated
 #define A_Axis				M4025
@@ -100,15 +109,15 @@ Version->*d
 // *****************************************************************************************
 // Motion Program Variables
 // *****************************************************************************************
-global Prev_A               // Previous coordinates for velocity calculations
-global Prev_B
-global Prev_C
-global Prev_U
-global Prev_V
-global Prev_W
-global Prev_X
-global Prev_Y
-global Prev_Z
+// global Prev_A               // Previous coordinates for velocity calculations
+// global Prev_B
+// global Prev_C
+// global Prev_U
+// global Prev_V
+// global Prev_W
+// global Prev_X
+// global Prev_Y
+// global Prev_Z
 
 global Time                 // Current coordinate values
 #define Current_A   Q71
@@ -121,7 +130,7 @@ global Time                 // Current coordinate values
 #define Current_Y   Q78
 #define Current_Z   Q79
 global UserFunc
-global VelMode
+//global VelMode
 
 #define Readback_A           Q81
 #define Readback_B           Q82
@@ -143,15 +152,15 @@ global X_Vel
 global Y_Vel
 global Z_Vel
 
-global A_Prev_Vel           // Previous velocity values
-global B_Prev_Vel
-global C_Prev_Vel
-global U_Prev_Vel
-global V_Prev_Vel
-global W_Prev_Vel
-global X_Prev_Vel
-global Y_Prev_Vel
-global Z_Prev_Vel
+// global A_Prev_Vel           // Previous velocity values
+// global B_Prev_Vel
+// global C_Prev_Vel
+// global U_Prev_Vel
+// global V_Prev_Vel
+// global W_Prev_Vel
+// global X_Prev_Vel
+// global Y_Prev_Vel
+// global Z_Prev_Vel
 
 global CalculatedBase       // Calculated temporary variable for Current base address
 global InverseTmpTime       // Calculated temporary variable for time in velocity calcs

--- a/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
+++ b/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
@@ -35,7 +35,6 @@ global Next_X_Vel(DoubleBuffLen)
 global Next_Y_Vel(DoubleBuffLen)
 global Next_Z_Vel(DoubleBuffLen)
 global Next_User(DoubleBuffLen)
-//global NextVelMode(DoubleBuffLen)
 
 #define AxesParser          M4024                      // Specifiers for what axes are activated
 #define A_Axis				M4025
@@ -109,15 +108,6 @@ Version->*d
 // *****************************************************************************************
 // Motion Program Variables
 // *****************************************************************************************
-// global Prev_A               // Previous coordinates for velocity calculations
-// global Prev_B
-// global Prev_C
-// global Prev_U
-// global Prev_V
-// global Prev_W
-// global Prev_X
-// global Prev_Y
-// global Prev_Z
 
 global Time                 // Current coordinate values
 #define Current_A   Q71
@@ -130,7 +120,6 @@ global Time                 // Current coordinate values
 #define Current_Y   Q78
 #define Current_Z   Q79
 global UserFunc
-//global VelMode
 
 #define Readback_A           Q81
 #define Readback_B           Q82
@@ -151,16 +140,6 @@ global W_Vel
 global X_Vel
 global Y_Vel
 global Z_Vel
-
-// global A_Prev_Vel           // Previous velocity values
-// global B_Prev_Vel
-// global C_Prev_Vel
-// global U_Prev_Vel
-// global V_Prev_Vel
-// global W_Prev_Vel
-// global X_Prev_Vel
-// global Y_Prev_Vel
-// global Z_Prev_Vel
 
 global CalculatedBase       // Calculated temporary variable for Current base address
 global InverseTmpTime       // Calculated temporary variable for time in velocity calcs

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -3670,7 +3670,7 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
 
     // Count how many buffers to fill
     char cmd[2*PMAC_MAX_CS_AXES+2][1024];  // 2 buffers (positions and velocities) per axis, plus time and user buffers
-    // cmd[18,19] are reserved for the time, velocity, user values
+    // cmd[18,19] are reserved for the user and time values
     pHardware_->startTrajectoryTimePointsCmd(cmd[2*PMAC_MAX_CS_AXES], cmd[2*PMAC_MAX_CS_AXES+1], writeAddress);
 
     posCmd = true;
@@ -3684,7 +3684,7 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
     posCmd = false;
     // cmd[9..17] are reserved for axis velocities
     for (int index = PMAC_MAX_CS_AXES; index < (2*PMAC_MAX_CS_AXES); index++) {
-      if ((1 << index & tScanAxisMask_) > 0) {
+      if ((1 << index-PMAC_MAX_CS_AXES & tScanAxisMask_) > 0) {     
         pHardware_->startAxisPointsCmd(cmd[index], index, writeAddress, tScanPmacBufferSize_,
                                        posCmd);
       }

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -3669,7 +3669,7 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
     writeAddress += epicsBufferPtr;
 
     // Count how many buffers to fill
-    char cmd[20][1024];
+    char cmd[2*PMAC_MAX_CS_AXES+2][1024];  // 2 buffers (positions and velocities) per axis, plus time and user buffers
     // cmd[18,19] are reserved for the time, velocity, user values
     pHardware_->startTrajectoryTimePointsCmd(cmd[2*PMAC_MAX_CS_AXES], cmd[2*PMAC_MAX_CS_AXES+1], writeAddress);
 
@@ -3744,9 +3744,9 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
         }
       }
       // And the axis velocities
-      for (int index = 0; index < PMAC_MAX_CS_AXES; index++) {
-        if ((1 << index & tScanAxisMask_) > 0) {
-          sprintf(cstr, "%s", cmd[index+PMAC_MAX_CS_AXES]);
+      for (int index = PMAC_MAX_CS_AXES; index < (2*PMAC_MAX_CS_AXES); index++) {
+        if ((1 << (index-PMAC_MAX_CS_AXES) & tScanAxisMask_) > 0) {
+          sprintf(cstr, "%s", cmd[index]);
           debug(DEBUG_VARIABLE, functionName, "Command", cstr);
           status = this->immediateWriteRead(cstr, response);
         }

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -4430,7 +4430,7 @@ asynStatus pmacController::tScanBuildProfileArray(double *positions, double *vel
   asynStatus status = asynSuccess;
   int index = 0;
   int csEnum = 0;
-  int calculateVel = -1;
+  int calculateVel = 1;
   double resolution = 1.0;
   double offset = 0.0;
   static const char *functionName = "tScanBuildProfileArray";

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -4485,7 +4485,8 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
 
   switch(profileVelMode_[index]) {
     // Average Previous -> Next
-    case 0:     
+    case 0:
+      if(times[index] ==  0 || times[index+1] == 0) break;
       inverse_deltaTime = 1000000 / (times[index]+times[index+1]);
       deltaPos = positions[index+1] - positions[index-1];
       velocities[index] = inverse_deltaTime * deltaPos;
@@ -4493,6 +4494,7 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
 
     // Real Previous -> Current
     case 1:
+    if(times[index] ==  0) break;
       inverse_deltaTime = 1000000 / (times[index]);
       deltaPos = positions[index] - positions[index-1];
       velocities[index] = 2.0 * inverse_deltaTime * deltaPos - velocities[index-1];
@@ -4500,6 +4502,7 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
 
     // Average Previous -> Current
     case 2:
+      if(times[index] ==  0) break;
       inverse_deltaTime = 1000000 / (times[index]);
       deltaPos = positions[index] - positions[index-1];
       velocities[index] = inverse_deltaTime * deltaPos;
@@ -4512,6 +4515,7 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
     
     // Average Current -> Next
     case 4:
+      if(times[index+1] == 0) break;
       inverse_deltaTime = 1000000 / (times[index+1]);
       deltaPos = positions[index+1] - positions[index];
       velocities[index] = inverse_deltaTime * deltaPos;

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -2916,14 +2916,14 @@ asynStatus pmacController::buildProfile(int csNo) {
       }
     } else {
       // Old Geobrick without additional memory.
-      // Check memory addresses are less than of equal to (0x10800-18*buffer_size)
-      if (tScanPmacBufferAddressA_ > (0x10800 - (10 * tScanPmacBufferSize_))) {
+      // Check memory addresses are less than of equal to (0x10800-19*buffer_size)
+      if (tScanPmacBufferAddressA_ > (0x10800 - (19 * tScanPmacBufferSize_))) {
         // Set the status to failure
         this->setBuildStatus(PROFILE_BUILD_DONE, PROFILE_STATUS_FAILURE,
                              "Buffer A memory address invalid");
         status = asynError;
       }
-      if (tScanPmacBufferAddressB_ > (0x10800 - (10 * tScanPmacBufferSize_))) {
+      if (tScanPmacBufferAddressB_ > (0x10800 - (19 * tScanPmacBufferSize_))) {
         // Set the status to failure
         this->setBuildStatus(PROFILE_BUILD_DONE, PROFILE_STATUS_FAILURE,
                              "Buffer B memory address invalid");

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -779,7 +779,6 @@ void pmacController::setupBrokerVariables(void) {
   pBroker_->addReadVariable(pmacMessageBroker::PMAC_SLOW_READ, PMAC_TRAJ_BUFFER_LENGTH);
   pBroker_->addReadVariable(pmacMessageBroker::PMAC_SLOW_READ, PMAC_TRAJ_BUFF_ADR_A);
   pBroker_->addReadVariable(pmacMessageBroker::PMAC_SLOW_READ, PMAC_TRAJ_BUFF_ADR_B);
-  // pBroker_->addReadVariable(pmacMessageBroker::PMAC_SLOW_READ, PMAC_TRAJ_VELOCITY_TYPE);
   pBroker_->addReadVariable(pmacMessageBroker::PMAC_SLOW_READ, PMAC_TRAJ_PROG_VERSION);
 
 
@@ -1422,7 +1421,7 @@ asynStatus pmacController::mediumUpdate(pmacCommandStore *sPtr) {
           } else {
             gpioOutputs += gpioBit << gpio;
           }
-         }
+        }
       }
       // Inputs
       for (gpio = 0; gpio < 16; gpio++) {
@@ -3026,7 +3025,7 @@ asynStatus pmacController::buildProfile(int csNo) {
   if (status == asynSuccess) {
     // Initialise the trajectory store
     status = pTrajectory_->initialise(numPoints);
-    
+
     if (status == asynSuccess) {
       // Set the trajectory store initial values
       status = pTrajectory_->append(tScanPositions_, tScanVelocities_, profileTimes_, profileUser_,
@@ -3682,7 +3681,7 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
     posCmd = false;
     // cmd[9..17] are reserved for axis velocities
     for (int index = PMAC_MAX_CS_AXES; index < (2*PMAC_MAX_CS_AXES); index++) {
-      if ((1 << index-PMAC_MAX_CS_AXES & tScanAxisMask_) > 0) {     
+      if ((1 << (index-PMAC_MAX_CS_AXES) & tScanAxisMask_) > 0) {
         pHardware_->startAxisPointsCmd(cmd[index], index, writeAddress, tScanPmacBufferSize_,
                                        posCmd);
       }
@@ -3694,7 +3693,7 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
            (tScanPointCtr_ < tScanNumPoints_)) {
       // Create the velmode/user/time memory writes:
       // First 4 bits are for user buffer %01X
-      // Remaining 24 bits are for delta times %06X
+      // Next 24 bits are for delta times %06X
       if (status == asynSuccess) {
         status = pTrajectory_->getUserMode(tScanPointCtr_, &userValue);
       }
@@ -4822,29 +4821,6 @@ asynStatus pmacMonitorVariables(const char *controller, const char *variablesStr
 
   return asynSuccess;
 }
-
-// /**
-//  * Set as true the PMAC controller boolean
-//  * tScanUseVelArray_ to use the velocity array in trajectory scans.
-//  * Default value is false.
-//  * @param controller The Asyn port name for the PMAC controller.
-//  */
-// asynStatus pmacSetTrajectoryUseVelArray(const char *controller)
-// {
-//   pmacController *pC = NULL;
-
-//   static const char *functionName = "pmacSetTrajectoryUseVelArray";
-
-//   pC = (pmacController *)findAsynPortDriver(controller);
-//   if (!pC)
-//   {
-//     printf("%s:%s: Error port %s not found\n",
-//            driverName, functionName, controller);
-//     return asynError;
-//   }
-
-//   return pC->pmacSetTrajectoryUseVelArray();
-// }
 
 /* Code for iocsh registration */
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -4454,9 +4454,12 @@ asynStatus pmacController::tScanBuildProfileArray(double *positions, double *vel
     debug(DEBUG_VARIABLE, functionName, "Resolution", resolution);
     debug(DEBUG_VARIABLE, functionName, "Offset", offset);
 
-    // Now loop over the points, applying offset and resolution and store
+    // Now loop over the points, applying offset and resolution to positions and store
     for (index = 0; index < numPoints; index++) {
       positions[index] = (eguProfilePositions_[axis][index] - offset) / resolution;
+    }
+    // Iterates over points, applying resolution to velocities or calculating from velocity mode
+    for (index = 0; index < numPoints; index++) {
       if(calculateVel == PMAC_TRAJ_VELOCITY_PROVIDED){
         velocities[index] = (eguProfileVelocities_[axis][index]) / resolution;
       } else if(calculateVel == PMAC_TRAJ_VELOCITY_CALCULATED){

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -1293,9 +1293,6 @@ asynStatus pmacController::slowUpdate(pmacCommandStore *sPtr) {
                  pvtTimeMode_);
       }
     }
-  } else if(cid_ == PMAC_CID_POWER_) {
-      debug(DEBUG_ERROR, functionName, "PVT time control mode not supported for PowerPMAC", PMAC_PVT_TIME_MODE);
-      status = asynError;
   }
 
   // Used for CPU calculation
@@ -2986,10 +2983,11 @@ asynStatus pmacController::buildProfile(int csNo) {
 
     // Check for any invalid times
     int maxValue = 0xFFFFFF;
-    // TODO:  Add cid check for pppmac
-    if (pvtTimeMode_ == 0) {
-      // In this mode the maximum time is 4095 ms
-      maxValue = 0x3E7C18;
+    if (cid_ == PMAC_CID_PMAC_ || cid_ == PMAC_CID_GEOBRICK_ || cid_ == PMAC_CID_CLIPPER_) {
+      if (pvtTimeMode_ == 0) {
+        // In this mode the maximum time is 4095 ms
+        maxValue = 0x3E7C18;
+      }
     }
     while (counter < numPointsToBuild) {
       // Profile times must be less than 24bit

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -3631,6 +3631,7 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
   char cstr[1024];
   const char *functionName = "sendTrajectoryDemands";
   bool firstVal = true;
+  bool posCmd = true;
 
   debug(DEBUG_FLOW, functionName);
   startTimer(DEBUG_TIMING, functionName);
@@ -3673,13 +3674,22 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
     // Count how many buffers to fill
     char cmd[20][1024];
     // cmd[18,19] are reserved for the time, velocity, user values
-    //TODO: #define more readable idx
     pHardware_->startTrajectoryTimePointsCmd(cmd[2*PMAC_MAX_CS_AXES], cmd[2*PMAC_MAX_CS_AXES+1], writeAddress);
 
+    posCmd = true;
     // cmd[0..8] are reserved for axis positions
     for (int index = 0; index < PMAC_MAX_CS_AXES; index++) {
       if ((1 << index & tScanAxisMask_) > 0) {
-        pHardware_->startAxisPointsCmd(cmd[index], index, writeAddress, tScanPmacBufferSize_);
+        pHardware_->startAxisPointsCmd(cmd[index], index, writeAddress, tScanPmacBufferSize_,
+                                       posCmd);
+      }
+    }
+    posCmd = false;
+    // cmd[9..17] are reserved for axis velocities
+    for (int index = PMAC_MAX_CS_AXES; index < (2*PMAC_MAX_CS_AXES); index++) {
+      if ((1 << index & tScanAxisMask_) > 0) {
+        pHardware_->startAxisPointsCmd(cmd[index], index, writeAddress, tScanPmacBufferSize_,
+                                       posCmd);
       }
     }
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -203,7 +203,6 @@ pmacController::pmacController(const char *portName, const char *lowLevelPortNam
   profileBuilt_ = false;
   appendAvailable_ = false;
   tScanShortScan_ = false;
-  tScanCalcVel_ = true;
   tScanExecuting_ = 0;
   tScanCSNo_ = 0;
   tScanAxisMask_ = 0;
@@ -2604,8 +2603,6 @@ asynStatus pmacController::writeInt32(asynUser *pasynUser, epicsInt32 value) {
     status = (this->pBroker_->report(pmacMessageBroker::PMAC_MEDIUM_READ) == asynSuccess) && status;
   } else if (function == PMAC_C_ReportSlow_) {
     status = (this->pBroker_->report(pmacMessageBroker::PMAC_SLOW_READ) == asynSuccess) && status;
-  } else if (function == PMAC_C_TrajCalcVel_) {
-    status = ((setIntegerParam(tScanCalcVel_, value) == asynSuccess) && status);
   } else if (function == PMAC_C_ProfileAppend_) {
     status = (this->appendToProfile() == asynSuccess) && status;
   } else if (function == PMAC_C_DebugCmd_) {

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -537,7 +537,6 @@ private:
     bool profileBuilt_;
     bool appendAvailable_;
     bool tScanShortScan_;           // Is the scan a short scan (< 3.0 seconds)
-    int tScanCalcVel_;              // Is the velocities being calculated
     int tScanExecuting_;            // Is a scan executing
     int tScanCSNo_;                 // The CS number of the executing scan
     int tScanNumPoints_;            // Total number of points in the scan

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -189,7 +189,7 @@
 #define PMAC_SLOW_LOOP_TIME   5000
 
 #define PMAC_PVT_TIME_MODE       "I42"   // PVT Time Control Mode (0=4,095 ms max time, 1=8,388,607 ms max time)
- 
+
 #define PMAC_CPU_PHASE_INTR      "M70"   // Time between phase interrupts (CPU cycles/2)
 #define PMAC_CPU_PHASE_TIME      "M71"   // Time for phase tasks (CPU cycles/2)
 #define PMAC_CPU_SERVO_TIME      "M72"   // Time for servo tasks (CPU cycles/2)

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -123,6 +123,15 @@
 #define PMAC_C_ProfilePositionsXString    "PROFILE_POSITIONS_X"
 #define PMAC_C_ProfilePositionsYString    "PROFILE_POSITIONS_Y"
 #define PMAC_C_ProfilePositionsZString    "PROFILE_POSITIONS_Z"
+#define PMAC_C_ProfileVelocitiesAString   "PROFILE_VELOCITIES_A"
+#define PMAC_C_ProfileVelocitiesBString   "PROFILE_VELOCITIES_B"
+#define PMAC_C_ProfileVelocitiesCString   "PROFILE_VELOCITIES_C"
+#define PMAC_C_ProfileVelocitiesUString   "PROFILE_VELOCITIES_U"
+#define PMAC_C_ProfileVelocitiesVString   "PROFILE_VELOCITIES_V"
+#define PMAC_C_ProfileVelocitiesWString   "PROFILE_VELOCITIES_W"
+#define PMAC_C_ProfileVelocitiesXString   "PROFILE_VELOCITIES_X"
+#define PMAC_C_ProfileVelocitiesYString   "PROFILE_VELOCITIES_Y"
+#define PMAC_C_ProfileVelocitiesZString   "PROFILE_VELOCITIES_Z"
 #define PMAC_C_CompTable0_WString         "PMAC_C_COMP_0"
 #define PMAC_C_CompTable1_WString         "PMAC_C_COMP_1"
 #define PMAC_C_CompTable2_WString         "PMAC_C_COMP_2"
@@ -156,6 +165,7 @@
 #define PMAC_C_TrajPercentString          "PMAC_C_TRAJ_PERCENT" // Percentage of scan complete
 #define PMAC_C_TrajEStatusString          "PMAC_C_TRAJ_ESTATUS" // Our report of tScan status
 #define PMAC_C_TrajProgString             "PMAC_C_TRAJ_PROG"    // Which motion program to execute
+#define PMAC_C_TrajVelTypeString          "PMAC_TRAJ_VELTYPE"   // Type of velocity for trajectory scan - 0: Velocity mode, 1: Velocity value
 #define PMAC_C_TrajProgVersionString      "PMAC_C_TRAJ_PROG_V"  // Motion program version number
 #define PMAC_C_TrajCodeVersionString      "PMAC_C_TRAJ_CODE_V"  // Version of this control code
 
@@ -179,13 +189,13 @@
 #define PMAC_SLOW_LOOP_TIME   5000
 
 #define PMAC_PVT_TIME_MODE       "I42"   // PVT Time Control Mode (0=4,095 ms max time, 1=8,388,607 ms max time)
-
-#define PMAC_CPU_PHASE_INTR      "M70" // Time between phase interrupts (CPU cycles/2)
-#define PMAC_CPU_PHASE_TIME      "M71" // Time for phase tasks (CPU cycles/2)
-#define PMAC_CPU_SERVO_TIME      "M72" // Time for servo tasks (CPU cycles/2)
-#define PMAC_CPU_RTI_TIME        "M73" // Time for RTI tasks (CPU cycles/2)
-#define PMAC_CPU_I8              "I8"
-#define PMAC_CPU_I7002           "I7002"
+ 
+#define PMAC_CPU_PHASE_INTR      "M70"   // Time between phase interrupts (CPU cycles/2)
+#define PMAC_CPU_PHASE_TIME      "M71"   // Time for phase tasks (CPU cycles/2)
+#define PMAC_CPU_SERVO_TIME      "M72"   // Time for servo tasks (CPU cycles/2)
+#define PMAC_CPU_RTI_TIME        "M73"   // Time for RTI tasks (CPU cycles/2)
+#define PMAC_CPU_I8              "I8"    // RTI period (Servo cycles - 1)
+#define PMAC_CPU_I7002           "I7002" // Servo clock divider (ServoClockFreq = PhaseClockFreq/(ServoClockDiv + 1) )
 
 #define PPMAC_CPU_FREQ           "Sys.CPUFreq"
 #define PPMAC_CPU_TYPE           "Sys.CPUType"
@@ -215,13 +225,18 @@
 #define PMAC_TRAJ_BUFF_FILL_A    "M4044" // Fill level of buffer A
 #define PMAC_TRAJ_BUFF_FILL_B    "M4045" // Fill level of buffer B
 #define PMAC_TRAJ_CURR_FILL      "M4046" // The indexes that current buffer has been filled up to
-#define PMAC_TRAJ_PROG_VERSION   "M4049" // The indexes that current buffer has been filled up to
+#define PMAC_TRAJ_PROG_VERSION   "M4049" // Trajectory program version
+
+#define PMAC_TRAJ_VELOCITY_TYPE  "M4085" // An int to indicate the usage of the velocities - 0: Pass the VelMode to the controller, 1: Pass the velocities values to the controller //TODO Check M-variable availability [lmds]
 
 #define PMAC_TRAJ_BUFFER_A 0
 #define PMAC_TRAJ_BUFFER_B 1
 
 #define PMAC_TRAJ_STATUS_RUNNING 1
 #define PMAC_TRAJ_STATUS_FINISHED 2
+
+#define PMAC_TRAJ_VELOCITY_MODE 0
+#define PMAC_TRAJ_VELOCITY_ARRAY 1
 
 class pmacCSMonitor;
 
@@ -330,6 +345,7 @@ public:
     asynStatus updateCsAssignmentParameters();
     asynStatus copyCsReadbackToDemand(bool manual);
     asynStatus tScanBuildProfileArray(double *positions, int axis, int numPoints);
+    asynStatus tScanBuildVelocityProfileArray(double *velocities, int axis, int numPoints);
     asynStatus tScanIncludedAxes(int *axisMask);
     void registerForLock(asynPortDriver *controller);
 
@@ -394,6 +410,15 @@ protected:
     int PMAC_C_ProfilePositionsX_;
     int PMAC_C_ProfilePositionsY_;
     int PMAC_C_ProfilePositionsZ_;
+    int PMAC_C_ProfileVelocitiesA_;
+    int PMAC_C_ProfileVelocitiesB_;
+    int PMAC_C_ProfileVelocitiesC_;
+    int PMAC_C_ProfileVelocitiesU_;
+    int PMAC_C_ProfileVelocitiesV_;
+    int PMAC_C_ProfileVelocitiesW_;
+    int PMAC_C_ProfileVelocitiesX_;
+    int PMAC_C_ProfileVelocitiesY_;
+    int PMAC_C_ProfileVelocitiesZ_;
     int PMAC_C_CompTable0_W;
     int PMAC_C_CompTable1_W;
     int PMAC_C_CompTable2_W;
@@ -425,6 +450,7 @@ protected:
     int PMAC_C_TrajPercent_;
     int PMAC_C_TrajEStatus_;
     int PMAC_C_TrajProg_;
+    int PMAC_C_TrajVelType_;
     int PMAC_C_TrajProgVersion_;
     int PMAC_C_TrajCodeVersion_;
     int PMAC_C_NoOfMsgs_;
@@ -512,6 +538,7 @@ private:
     bool profileBuilt_;
     bool appendAvailable_;
     bool tScanShortScan_;           // Is the scan a short scan (< 3.0 seconds)
+    int tScanVelType_;              // Which velocity type () // TODO Improve comment [lmds]
     int tScanExecuting_;            // Is a scan executing
     int tScanCSNo_;                 // The CS number of the executing scan
     int tScanNumPoints_;            // Total number of points in the scan
@@ -527,6 +554,8 @@ private:
     double tScanPmacProgVersion_;
     double **eguProfilePositions_;  // 2D array of profile positions in EGU (1 array for each axis)
     double **tScanPositions_;       // 2D array of profile positions (1 array for each axis)
+    double **eguProfileVelocities_; // 2D array of profile velocities in EGU (1 array for each axis)
+    double **tScanVelocities_;      // 2D array of profile velocities (1 array for each axis)
     int *profileUser_;              // Array of profile user values
     int *profileVelMode_;           // Array of profile velocity modes
     epicsEventId startEventId_;

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -165,11 +165,11 @@
 #define PMAC_C_TrajPercentString          "PMAC_C_TRAJ_PERCENT" // Percentage of scan complete
 #define PMAC_C_TrajEStatusString          "PMAC_C_TRAJ_ESTATUS" // Our report of tScan status
 #define PMAC_C_TrajProgString             "PMAC_C_TRAJ_PROG"    // Which motion program to execute
-#define PMAC_C_TrajVelTypeString          "PMAC_TRAJ_VELTYPE"   // Type of velocity for trajectory scan - 0: Velocity mode, 1: Velocity value
+#define PMAC_C_TrajCalcVelString          "PMAC_TRAJ_CALCVEL"   // Velocity array calculation - 0: No calculation - receives velocities directly; 1: Calculate - calculate the velocities base on time, position and velocity mode
 #define PMAC_C_TrajProgVersionString      "PMAC_C_TRAJ_PROG_V"  // Motion program version number
 #define PMAC_C_TrajCodeVersionString      "PMAC_C_TRAJ_CODE_V"  // Version of this control code
 
-#define PMAC_TRAJECTORY_VERSION 3
+#define PMAC_TRAJECTORY_VERSION 4
 
 #define PMAC_CPU_GEO_240MHZ               "DSP56321"            // Approved geobrick for trajectory scans
 #define PMAC_CPU_CLIPPER                  "DSP56303"            // Allowed for trajectory scans
@@ -227,16 +227,14 @@
 #define PMAC_TRAJ_CURR_FILL      "M4046" // The indexes that current buffer has been filled up to
 #define PMAC_TRAJ_PROG_VERSION   "M4049" // Trajectory program version
 
-#define PMAC_TRAJ_VELOCITY_TYPE  "M4085" // An int to indicate the usage of the velocities - 0: Pass the VelMode to the controller, 1: Pass the velocities values to the controller //TODO Check M-variable availability [lmds]
-
 #define PMAC_TRAJ_BUFFER_A 0
 #define PMAC_TRAJ_BUFFER_B 1
 
 #define PMAC_TRAJ_STATUS_RUNNING 1
 #define PMAC_TRAJ_STATUS_FINISHED 2
 
-#define PMAC_TRAJ_VELOCITY_MODE 0
-#define PMAC_TRAJ_VELOCITY_ARRAY 1
+#define PMAC_TRAJ_VELOCITY_PROVIDED 0
+#define PMAC_TRAJ_VELOCITY_CALCULATED 1
 
 class pmacCSMonitor;
 
@@ -344,8 +342,9 @@ public:
     asynStatus executeManualGroup();
     asynStatus updateCsAssignmentParameters();
     asynStatus copyCsReadbackToDemand(bool manual);
-    asynStatus tScanBuildProfileArray(double *positions, int axis, int numPoints);
-    asynStatus tScanBuildVelocityProfileArray(double *velocities, int axis, int numPoints);
+    asynStatus tScanBuildProfileArray(double *positions, double *velocities, double *times, int axis, int numPoints);
+    asynStatus tScanCalculateVelocityArray(double *positions, double *velocities, double *times, int index);
+    // asynStatus tScanBuildVelocityProfileArray(double *velocities, int axis, int numPoints);
     asynStatus tScanIncludedAxes(int *axisMask);
     void registerForLock(asynPortDriver *controller);
 
@@ -450,7 +449,7 @@ protected:
     int PMAC_C_TrajPercent_;
     int PMAC_C_TrajEStatus_;
     int PMAC_C_TrajProg_;
-    int PMAC_C_TrajVelType_;
+    int PMAC_C_TrajCalcVel_;
     int PMAC_C_TrajProgVersion_;
     int PMAC_C_TrajCodeVersion_;
     int PMAC_C_NoOfMsgs_;
@@ -538,7 +537,7 @@ private:
     bool profileBuilt_;
     bool appendAvailable_;
     bool tScanShortScan_;           // Is the scan a short scan (< 3.0 seconds)
-    int tScanVelType_;              // Which velocity type () // TODO Improve comment [lmds]
+    int tScanCalcVel_;              // Is the velocities being calculated
     int tScanExecuting_;            // Is a scan executing
     int tScanCSNo_;                 // The CS number of the executing scan
     int tScanNumPoints_;            // Total number of points in the scan

--- a/pmacApp/src/pmacHardwareInterface.h
+++ b/pmacApp/src/pmacHardwareInterface.h
@@ -84,14 +84,14 @@ public:
 
     virtual std::string parseCSMappingResult(const std::string mappingResult) = 0;
 
-    virtual void startTrajectoryTimePointsCmd(char *vel_cmd, char *user_cmd,
-                                              char *time_cmd, int addr) = 0;
+    virtual void startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd, 
+                                              int addr) = 0;
 
-    virtual void addTrajectoryTimePointCmd(char *velCmd, char *userCmd, char *timeCmd,
-                                           int velocityMode, int userFunc, int time,
+    virtual void addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,
+                                           int userFunc, int time,
                                            bool firstVal) = 0;
 
-    virtual void startAxisPointsCmd(char *axis_cmd, int axis, int addr, int buffSize) = 0;
+    virtual void startAxisPointsCmd(char *axis_cmd, int axis, int addr, int buffSize, bool posCmd) = 0;
 
     virtual void addAxisPointCmd(char *axis_cmd, int axis, double pos, int buffSize,
                                  bool firstVal) = 0;

--- a/pmacApp/src/pmacHardwareInterface.h
+++ b/pmacApp/src/pmacHardwareInterface.h
@@ -84,7 +84,7 @@ public:
 
     virtual std::string parseCSMappingResult(const std::string mappingResult) = 0;
 
-    virtual void startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd, 
+    virtual void startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd,
                                               int addr) = 0;
 
     virtual void addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -306,7 +306,7 @@ std::string pmacHardwarePower::parseCSMappingResult(const std::string mappingRes
   return result;
 }
 
-void pmacHardwarePower::startTrajectoryTimePointsCmd(char *userCmd, char *timeCmd, 
+void pmacHardwarePower::startTrajectoryTimePointsCmd(char *userCmd, char *timeCmd,
                                                      int addr) {
   static const char *functionName = "startTrajectoryTimePointsCmd";
 

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -306,45 +306,46 @@ std::string pmacHardwarePower::parseCSMappingResult(const std::string mappingRes
   return result;
 }
 
-void pmacHardwarePower::startTrajectoryTimePointsCmd(char *velCmd, char *userCmd,
-                                                     char *timeCmd, int addr) {
+void pmacHardwarePower::startTrajectoryTimePointsCmd(char *userCmd, char *timeCmd, 
+                                                     int addr) {
   static const char *functionName = "startTrajectoryTimePointsCmd";
 
   debug(DEBUG_FLOW, functionName, "addr %d", addr);
 
-  sprintf(velCmd, "Next_Vel(%d)=", addr);
   sprintf(userCmd, "Next_User(%d)=", addr);
   sprintf(timeCmd, "Next_Time(%d)=", addr);
 
 }
 
-void pmacHardwarePower::addTrajectoryTimePointCmd(char *velCmd, char *userCmd, char *timeCmd,
-                                                  int velocityMode, int userFunc, int time,
+void pmacHardwarePower::addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,
+                                                  int userFunc, int time,
                                                   bool firstVal) {
   static const char *functionName = "addTrajectoryTimePointCmd";
 
-  debugf(DEBUG_FLOW, functionName, "velCmd %s\nuserCmd %s\ntimeCmd %s\nvel %d, user %d, time %d",
-    velCmd, userCmd, timeCmd, velocityMode, userFunc, time);
+  debugf(DEBUG_FLOW, functionName, "userCmd %s\ntimeCmd %s\nvel %d, user %d, time %d",
+         userCmd, timeCmd, userFunc, time);
 
   if(firstVal) {
-    sprintf(velCmd, "%s%d", velCmd, velocityMode);
     sprintf(userCmd, "%s%d", userCmd, userFunc);
     sprintf(timeCmd, "%s%d", timeCmd, time);
   }
   else {
-    sprintf(velCmd, "%s,%d", velCmd, velocityMode);
     sprintf(userCmd, "%s,%d", userCmd, userFunc);
     sprintf(timeCmd, "%s,%d", timeCmd, time);
   }
 }
 
-void pmacHardwarePower::startAxisPointsCmd(char *axisCmd, int axis, int addr, int ) {
+void pmacHardwarePower::startAxisPointsCmd(char *axisCmd, int axis, int addr, int , bool posCmd ) {
   const char axes[] = "ABCUVWXYZ";
   static const char *functionName = "startAxisPointsCmd";
 
   debugf(DEBUG_FLOW, functionName, "cmd %s, axis %d, addr %d", axisCmd, axis, addr);
 
-  sprintf(axisCmd, "Next_%c(%d)=", axes[axis], addr);
+  if(posCmd) {
+    sprintf(axisCmd, "Next_%c(%d)=", axes[axis], addr);
+  } else {
+    sprintf(axisCmd, "Next_%c_Vel(%d)=", axes[axis], addr);
+  }
 }
 
 void pmacHardwarePower::addAxisPointCmd(char *axisCmd, int , double pos, int ,

--- a/pmacApp/src/pmacHardwarePower.h
+++ b/pmacApp/src/pmacHardwarePower.h
@@ -41,7 +41,7 @@ public:
 
     std::string parseCSMappingResult(const std::string mappingResult);
 
-    void startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd, 
+    void startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd,
                                       int addr);
 
     void addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,

--- a/pmacApp/src/pmacHardwarePower.h
+++ b/pmacApp/src/pmacHardwarePower.h
@@ -41,14 +41,14 @@ public:
 
     std::string parseCSMappingResult(const std::string mappingResult);
 
-    void startTrajectoryTimePointsCmd(char *vel_cmd, char *user_cmd,
-                                      char *time_cmd, int addr);
+    void startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd, 
+                                      int addr);
 
-    void addTrajectoryTimePointCmd(char *velCmd, char *userCmd, char *timeCmd,
-                                   int velocityMode, int userFunc, int time,
+    void addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,
+                                   int userFunc, int time,
                                    bool firstVal);
 
-    void startAxisPointsCmd(char *axis_cmd, int axis, int addr, int buffSize);
+    void startAxisPointsCmd(char *axis_cmd, int axis, int addr, int buffSize, bool posCmd);
 
     void addAxisPointCmd(char *axis_cmd, int axis, double pos, int buffSize,
                                  bool firstVal);

--- a/pmacApp/src/pmacHardwareTurbo.cpp
+++ b/pmacApp/src/pmacHardwareTurbo.cpp
@@ -326,29 +326,29 @@ std::string pmacHardwareTurbo::parseCSMappingResult(const std::string mappingRes
   return mappingResult;
 }
 
-void pmacHardwareTurbo::startTrajectoryTimePointsCmd(char *vel_cmd, char *user_cmd,
-                                                     char *time_cmd, int addr) {
+void pmacHardwareTurbo::startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd, 
+                                                     int addr) {
   static const char *functionName = "startTrajectoryTimePointsCmd";
 
   debug(DEBUG_FLOW, functionName, "addr %d", addr);
 
-  sprintf(vel_cmd, "WL:$%X", addr);
-  user_cmd[0] = time_cmd[0] = 0;
+  sprintf(user_cmd, "WL:$%X", addr);
+  time_cmd[0] = 0;
 }
 
-void pmacHardwareTurbo::addTrajectoryTimePointCmd(char *velCmd, char *userCmd, char *timeCmd,
-                                                  int velocityMode, int userFunc, int time,
+void pmacHardwareTurbo::addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,
+                                                  int userFunc, int time,
                                                   bool ) {
   static const char *functionName = "addTrajectoryTimePointCmd";
 
-  debugf(DEBUG_FLOW, functionName, "velCmd %s\nuserCmd %s\ntimeCmd %s\nvel %d, user %d, time %d",
-         velCmd, userCmd, timeCmd, velocityMode, userFunc, time);
+  debugf(DEBUG_FLOW, functionName, "userCmd %s\ntimeCmd %s\nuser %d, time %d",
+         userCmd, timeCmd, userFunc, time);
 
-  sprintf(velCmd, "%s,$%01X%01X%06X", velCmd, velocityMode, userFunc, time);
-  userCmd[0] = timeCmd[0] = 0;
+  sprintf(userCmd, "%s,$%01X%06X", userCmd, userFunc, time);
+  timeCmd[0] = 0;
 }
 
-void pmacHardwareTurbo::startAxisPointsCmd(char *axisCmd, int axis, int addr, int buffSize) {
+void pmacHardwareTurbo::startAxisPointsCmd(char *axisCmd, int axis, int addr, int buffSize, bool) {
   static const char *functionName = "startAxisPointsCmd";
 
   debugf(DEBUG_FLOW, functionName, "cmd %s, axis %d, addr %d", axisCmd, axis, addr);

--- a/pmacApp/src/pmacHardwareTurbo.cpp
+++ b/pmacApp/src/pmacHardwareTurbo.cpp
@@ -326,7 +326,7 @@ std::string pmacHardwareTurbo::parseCSMappingResult(const std::string mappingRes
   return mappingResult;
 }
 
-void pmacHardwareTurbo::startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd, 
+void pmacHardwareTurbo::startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd,
                                                      int addr) {
   static const char *functionName = "startTrajectoryTimePointsCmd";
 

--- a/pmacApp/src/pmacHardwareTurbo.h
+++ b/pmacApp/src/pmacHardwareTurbo.h
@@ -41,7 +41,7 @@ public:
 
     std::string parseCSMappingResult(const std::string mappingResult);
 
-    void startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd, 
+    void startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd,
                                       int addr);
 
     void addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,

--- a/pmacApp/src/pmacHardwareTurbo.h
+++ b/pmacApp/src/pmacHardwareTurbo.h
@@ -41,14 +41,14 @@ public:
 
     std::string parseCSMappingResult(const std::string mappingResult);
 
-    void startTrajectoryTimePointsCmd(char *vel_cmd, char *user_cmd,
-                                      char *time_cmd, int addr);
+    void startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd, 
+                                      int addr);
 
-    void addTrajectoryTimePointCmd(char *velCmd, char *userCmd, char *timeCmd,
-                                   int velocityMode, int userFunc, int time,
+    void addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,
+                                   int userFunc, int time,
                                    bool firstVal);
 
-    void startAxisPointsCmd(char *axis_cmd, int axis, int addr, int buffSize);
+    void startAxisPointsCmd(char *axis_cmd, int axis, int addr, int buffSize, bool posCmd);
 
     void addAxisPointCmd(char *axis_cmd, int axis, double pos, int buffSize,
                                  bool firstVal);

--- a/pmacApp/src/pmacTrajectory.cpp
+++ b/pmacApp/src/pmacTrajectory.cpp
@@ -40,7 +40,7 @@ pmacTrajectory::~pmacTrajectory() {
     }
     free(profileVelocities_);
   }
-  
+
   if (profileTimes_) {
     free(profileTimes_);
   }
@@ -325,7 +325,7 @@ asynStatus pmacTrajectory::getVelocity(int axis, int index, double *velocity) {
   static const char *functionName = "readVelocity";
   debug(DEBUG_TRACE, functionName, "Called with axis", axis);
   debug(DEBUG_TRACE, functionName, "Called with index", index);
-  
+
   // Check the axis is valid
   if (axis < 0 || axis >= noOfAxes_) {
     debug(DEBUG_ERROR, functionName, "Invalid axis requested", axis);

--- a/pmacApp/src/pmacTrajectory.h
+++ b/pmacApp/src/pmacTrajectory.h
@@ -19,9 +19,7 @@ public:
 
     asynStatus initialise(int noOfPoints);
 
-    asynStatus appendVelMode(double **positions, double *times, int *user, int *velocityMode, int noOfPoints);
-    
-    asynStatus appendVelArray(double **positions, double **velocities, double *times, int *user, int noOfPoints);
+    asynStatus append(double **positions, double **velocities, double *times, int *user, int noOfPoints);
 
     int getNoOfAxes();
 
@@ -29,13 +27,9 @@ public:
 
     int getNoOfValidPoints();
 
-    int getTypeOfVelocityProfile();
-
     asynStatus getTime(int index, int *time);
 
     asynStatus getUserMode(int index, int *user);
-
-    asynStatus getVelocityMode(int index, int *velocityMode);
 
     asynStatus getPosition(int axis, int index, double *position);
 
@@ -47,12 +41,11 @@ private:
     int noOfAxes_;
     int totalNoOfPoints_;           // Total number of points in the scan
     int noOfValidPoints_;           // Number of prepared points in the scan (based on delta times)
-    int typeOfVelocityProfile_;     // TODO: ADD comment [lmds]
     double **profilePositions_;     // 2D array of profile positions (1 array for each axis)
     double **profileVelocities_;    // 2D array of profile velocities (1 array for each axis)
     int *profileTimes_;             // Array of profile delta times for scan
     int *profileUser_;              // Array of profile user values
     int *profileVelMode_;           // Array of profile velocity modes
 };
-    
+
 #endif /* PMACAPP_SRC_PMACTRAJECTORY_H_ */

--- a/pmacApp/src/pmacTrajectory.h
+++ b/pmacApp/src/pmacTrajectory.h
@@ -19,7 +19,9 @@ public:
 
     asynStatus initialise(int noOfPoints);
 
-    asynStatus append(double **positions, double *times, int *user, int *velocity, int noOfPoints);
+    asynStatus appendVelMode(double **positions, double *times, int *user, int *velocityMode, int noOfPoints);
+    
+    asynStatus appendVelArray(double **positions, double **velocities, double *times, int *user, int noOfPoints);
 
     int getNoOfAxes();
 
@@ -27,13 +29,17 @@ public:
 
     int getNoOfValidPoints();
 
+    int getTypeOfVelocityProfile();
+
     asynStatus getTime(int index, int *time);
 
     asynStatus getUserMode(int index, int *user);
 
-    asynStatus getVelocityMode(int index, int *velocity);
+    asynStatus getVelocityMode(int index, int *velocityMode);
 
     asynStatus getPosition(int axis, int index, double *position);
+
+    asynStatus getVelocity(int axis, int index, double *velocity);
 
     void report();
 
@@ -41,10 +47,12 @@ private:
     int noOfAxes_;
     int totalNoOfPoints_;           // Total number of points in the scan
     int noOfValidPoints_;           // Number of prepared points in the scan (based on delta times)
+    int typeOfVelocityProfile_;     // TODO: ADD comment [lmds]
     double **profilePositions_;     // 2D array of profile positions (1 array for each axis)
+    double **profileVelocities_;    // 2D array of profile velocities (1 array for each axis)
     int *profileTimes_;             // Array of profile delta times for scan
     int *profileUser_;              // Array of profile user values
     int *profileVelMode_;           // Array of profile velocity modes
 };
-
+    
 #endif /* PMACAPP_SRC_PMACTRAJECTORY_H_ */

--- a/pmacApp/unitTests/test_PMACTrajectory.cpp
+++ b/pmacApp/unitTests/test_PMACTrajectory.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   BOOST_CHECK_EQUAL(trajectory.getTotalNoOfPoints(), 10000);
 
   // Set up some values
-  int vel[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  // int velMode[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   int user[10] = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
   double time[10] = {21, 22, 23, 24, 25, 26, 27, 28, 29, 30};
 
@@ -63,8 +63,17 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
       pos[axis][index] = (double)((axis*10)+index);
     }
   }
+
+  double *vel[9];
+  for (int axis = 0; axis < 9; axis++){
+    vel[axis] = (double *)malloc(sizeof(double) * 10);
+    for (int index = 0; index < 10; index++){
+      vel[axis][index] = (double)(axis+(index*10));
+    }
+  }
   // Append the values
-  trajectory.append(pos, time, user, vel, 10);
+  // trajectory.append(pos, time, user, velMode, 10);
+  trajectory.append(pos, vel, time, user, 10);
 
   // Verify the indexes after append
   BOOST_CHECK_EQUAL(trajectory.getNoOfAxes(), 9);
@@ -72,7 +81,8 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   BOOST_CHECK_EQUAL(trajectory.getTotalNoOfPoints(), 10000);
 
   // Append the values
-  trajectory.append(pos, time, user, vel, 10);
+  // trajectory.append(pos, time, user, velMode, 10);
+  trajectory.append(pos, vel, time, user, 10);
 
   // Verify the indexes after append
   BOOST_CHECK_EQUAL(trajectory.getNoOfAxes(), 9);
@@ -86,14 +96,19 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   int userVal;
   BOOST_CHECK_EQUAL(trajectory.getUserMode(-1, &userVal), asynError);
   BOOST_CHECK_EQUAL(trajectory.getUserMode(20, &userVal), asynError);
-  int velocityVal;
-  BOOST_CHECK_EQUAL(trajectory.getVelocityMode(-1, &velocityVal), asynError);
-  BOOST_CHECK_EQUAL(trajectory.getVelocityMode(20, &velocityVal), asynError);
+  // int velocityVal;
+  // BOOST_CHECK_EQUAL(trajectory.getVelocityMode(-1, &velocityVal), asynError);
+  // BOOST_CHECK_EQUAL(trajectory.getVelocityMode(20, &velocityVal), asynError);
   double positionVal;
   BOOST_CHECK_EQUAL(trajectory.getPosition(-1, 0, &positionVal), asynError);
   BOOST_CHECK_EQUAL(trajectory.getPosition(9, 0, &positionVal), asynError);
   BOOST_CHECK_EQUAL(trajectory.getPosition(0, -1, &positionVal), asynError);
   BOOST_CHECK_EQUAL(trajectory.getPosition(0, 20, &positionVal), asynError);
+  double velocityVal;
+  BOOST_CHECK_EQUAL(trajectory.getVelocity(-1, 0, &velocityVal), asynError);
+  BOOST_CHECK_EQUAL(trajectory.getVelocity(9, 0, &velocityVal), asynError);
+  BOOST_CHECK_EQUAL(trajectory.getVelocity(0, -1, &velocityVal), asynError);
+  BOOST_CHECK_EQUAL(trajectory.getVelocity(0, 20, &velocityVal), asynError);
 
   // Now check some valid read outs
   BOOST_CHECK_EQUAL(trajectory.getTime(5, &timeVal), asynSuccess);
@@ -104,18 +119,23 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   BOOST_CHECK_EQUAL(userVal, 8);
   BOOST_CHECK_EQUAL(trajectory.getUserMode(19, &userVal), asynSuccess);
   BOOST_CHECK_EQUAL(userVal, 1);
-  BOOST_CHECK_EQUAL(trajectory.getVelocityMode(4, &velocityVal), asynSuccess);
-  BOOST_CHECK_EQUAL(velocityVal, 5);
-  BOOST_CHECK_EQUAL(trajectory.getVelocityMode(14, &velocityVal), asynSuccess);
-  BOOST_CHECK_EQUAL(velocityVal, 5);
+  // BOOST_CHECK_EQUAL(trajectory.getVelocityMode(4, &velocityVal), asynSuccess);
+  // BOOST_CHECK_EQUAL(velocityVal, 5);
+  // BOOST_CHECK_EQUAL(trajectory.getVelocityMode(14, &velocityVal), asynSuccess);
+  // BOOST_CHECK_EQUAL(velocityVal, 5);
   BOOST_CHECK_EQUAL(trajectory.getPosition(2, 5, &positionVal), asynSuccess);
   BOOST_CHECK_EQUAL(positionVal, 25);
   BOOST_CHECK_EQUAL(trajectory.getPosition(4, 6, &positionVal), asynSuccess);
   BOOST_CHECK_EQUAL(positionVal, 46);
+  BOOST_CHECK_EQUAL(trajectory.getVelocity(2, 5, &positionVal), asynSuccess);
+  BOOST_CHECK_EQUAL(velocityVal, 52);
+  BOOST_CHECK_EQUAL(trajectory.getPosition(4, 6, &positionVal), asynSuccess);
+  BOOST_CHECK_EQUAL(velocityVal, 64);
 
   // Append points up to the maximum
   for (int index = 0; index < 998; index++){
-    trajectory.append(pos, time, user, vel, 10);
+    // trajectory.append(pos, time, user, velMode, 10); 
+    trajectory.append(pos, vel, time, user, 10);
   }
 
   // Verify the indexes after append
@@ -124,7 +144,8 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   BOOST_CHECK_EQUAL(trajectory.getTotalNoOfPoints(), 10000);
 
   // Try to append once more and verify it fails
-  BOOST_CHECK_EQUAL(trajectory.append(pos, time, user, vel, 10), asynError);
+  // BOOST_CHECK_EQUAL(trajectory.append(pos, time, user, velMode, 10), asynError);
+  BOOST_CHECK_EQUAL(trajectory.append(pos, vel, time, user, 10), asynError);
   BOOST_CHECK_EQUAL(trajectory.getNoOfAxes(), 9);
   BOOST_CHECK_EQUAL(trajectory.getNoOfValidPoints(), 10000);
   BOOST_CHECK_EQUAL(trajectory.getTotalNoOfPoints(), 10000);

--- a/pmacApp/unitTests/test_PMACTrajectory.cpp
+++ b/pmacApp/unitTests/test_PMACTrajectory.cpp
@@ -52,7 +52,6 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   BOOST_CHECK_EQUAL(trajectory.getTotalNoOfPoints(), 10000);
 
   // Set up some values
-  // int velMode[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   int user[10] = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
   double time[10] = {21, 22, 23, 24, 25, 26, 27, 28, 29, 30};
 
@@ -72,7 +71,6 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
     }
   }
   // Append the values
-  // trajectory.append(pos, time, user, velMode, 10);
   trajectory.append(pos, vel, time, user, 10);
 
   // Verify the indexes after append
@@ -81,7 +79,6 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   BOOST_CHECK_EQUAL(trajectory.getTotalNoOfPoints(), 10000);
 
   // Append the values
-  // trajectory.append(pos, time, user, velMode, 10);
   trajectory.append(pos, vel, time, user, 10);
 
   // Verify the indexes after append
@@ -96,9 +93,6 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   int userVal;
   BOOST_CHECK_EQUAL(trajectory.getUserMode(-1, &userVal), asynError);
   BOOST_CHECK_EQUAL(trajectory.getUserMode(20, &userVal), asynError);
-  // int velocityVal;
-  // BOOST_CHECK_EQUAL(trajectory.getVelocityMode(-1, &velocityVal), asynError);
-  // BOOST_CHECK_EQUAL(trajectory.getVelocityMode(20, &velocityVal), asynError);
   double positionVal;
   BOOST_CHECK_EQUAL(trajectory.getPosition(-1, 0, &positionVal), asynError);
   BOOST_CHECK_EQUAL(trajectory.getPosition(9, 0, &positionVal), asynError);
@@ -119,22 +113,17 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   BOOST_CHECK_EQUAL(userVal, 8);
   BOOST_CHECK_EQUAL(trajectory.getUserMode(19, &userVal), asynSuccess);
   BOOST_CHECK_EQUAL(userVal, 1);
-  // BOOST_CHECK_EQUAL(trajectory.getVelocityMode(4, &velocityVal), asynSuccess);
-  // BOOST_CHECK_EQUAL(velocityVal, 5);
-  // BOOST_CHECK_EQUAL(trajectory.getVelocityMode(14, &velocityVal), asynSuccess);
-  // BOOST_CHECK_EQUAL(velocityVal, 5);
   BOOST_CHECK_EQUAL(trajectory.getPosition(2, 5, &positionVal), asynSuccess);
   BOOST_CHECK_EQUAL(positionVal, 25);
   BOOST_CHECK_EQUAL(trajectory.getPosition(4, 6, &positionVal), asynSuccess);
   BOOST_CHECK_EQUAL(positionVal, 46);
-  BOOST_CHECK_EQUAL(trajectory.getVelocity(2, 5, &positionVal), asynSuccess);
+  BOOST_CHECK_EQUAL(trajectory.getVelocity(2, 5, &velocityVal), asynSuccess);
   BOOST_CHECK_EQUAL(velocityVal, 52);
-  BOOST_CHECK_EQUAL(trajectory.getPosition(4, 6, &positionVal), asynSuccess);
+  BOOST_CHECK_EQUAL(trajectory.getVelocity(4, 6, &velocityVal), asynSuccess);
   BOOST_CHECK_EQUAL(velocityVal, 64);
 
   // Append points up to the maximum
   for (int index = 0; index < 998; index++){
-    // trajectory.append(pos, time, user, velMode, 10); 
     trajectory.append(pos, vel, time, user, 10);
   }
 
@@ -144,7 +133,6 @@ BOOST_AUTO_TEST_CASE(test_PMACTrajectory)
   BOOST_CHECK_EQUAL(trajectory.getTotalNoOfPoints(), 10000);
 
   // Try to append once more and verify it fails
-  // BOOST_CHECK_EQUAL(trajectory.append(pos, time, user, velMode, 10), asynError);
   BOOST_CHECK_EQUAL(trajectory.append(pos, vel, time, user, 10), asynError);
   BOOST_CHECK_EQUAL(trajectory.getNoOfAxes(), 9);
   BOOST_CHECK_EQUAL(trajectory.getNoOfValidPoints(), 10000);

--- a/test/test_pmac/test_regression/test_cs_consistent.py
+++ b/test/test_pmac/test_regression/test_cs_consistent.py
@@ -162,7 +162,7 @@ class TestMakeCsConsistent(TestCase):
         command = "&3 Q71=90000"
         tb.send_command(command)
         # this check is probably not required but leaving it in to verify reliability
-        self.assertEquals(tb.get_command(), command)
+        self.assertEqual(tb.get_command(), command)
 
         # if this succeeds without error then we are all good
         trajectory_quick_scan(self, tb)
@@ -231,7 +231,7 @@ class TestMakeCsConsistent(TestCase):
             tb.send_command("#1J:{}".format(move))
             monitor.wait_for_one_move(1, throw=False)
             # this should put axis 1 at {move}mm
-            self.assertEquals(tb.m1.pos, move)
+            self.assertEqual(tb.m1.pos, move)
 
             # now move the CS axis Height
             tb.height.go(cs_move)

--- a/test/test_pmac/test_regression/test_cs_switching.py
+++ b/test/test_pmac/test_regression/test_cs_switching.py
@@ -34,7 +34,7 @@ class TestCsSwitching(TestCase):
             tb.m4.set_cs_assignment("I")
             tb.height.go_direct(1)
 
-            self.assertEquals(tb.height.alarm, 0)
+            self.assertEqual(tb.height.alarm, 0)
             self.assertAlmostEqual(tb.m3.pos, 1, DECIMALS)
 
     def test_group_switch(self):

--- a/test/test_pmac/test_system/test_general.py
+++ b/test/test_pmac/test_system/test_general.py
@@ -55,41 +55,41 @@ class TestGeneral(TestCase):
 
         try:
             problem = ca.caget("{}:FEEDRATE_PROBLEM_RBV".format(brick_pv_root))
-            self.assertEquals(problem, 0)
+            self.assertEqual(problem, 0)
 
             # create a feedrate problem by manually setting a configured feedrate
             tb.send_command("&2%50")
             tb.poll_all_now()
             Sleep(2)  # Todo, does requiring this represent an issue?
             problem = ca.caget("{}:FEEDRATE_PROBLEM_RBV".format(brick_pv_root))
-            self.assertEquals(problem, 1)
+            self.assertEqual(problem, 1)
 
             # use driver feature to reset All feedrates
             ca.caput("{}:FEEDRATE".format(brick_pv_root), 100, wait=True)
             tb.poll_all_now()
             Sleep(2)
             problem = ca.caget("{}:FEEDRATE_PROBLEM_RBV".format(brick_pv_root))
-            self.assertEquals(problem, 0)
+            self.assertEqual(problem, 0)
 
             # create a feedrate problem by manually setting another configured feedrate
             tb.send_command("&3%50")
             tb.poll_all_now()
             Sleep(2)
             problem = ca.caget("{}:FEEDRATE_PROBLEM_RBV".format(brick_pv_root))
-            self.assertEquals(problem, 1)
+            self.assertEqual(problem, 1)
 
             # use driver feature to reset All feedrates
             ca.caput("{}:FEEDRATE".format(brick_pv_root), 100, wait=True)
             tb.poll_all_now()
             Sleep(2)
             problem = ca.caget("{}:FEEDRATE_PROBLEM_RBV".format(brick_pv_root))
-            self.assertEquals(problem, 0)
+            self.assertEqual(problem, 0)
 
             # check that non-configured CS has no effect
             tb.send_command("&4%50")
             tb.poll_all_now()
             Sleep(2)
             problem = ca.caget("{}:FEEDRATE_PROBLEM_RBV".format(brick_pv_root))
-            self.assertEquals(problem, 0)
+            self.assertEqual(problem, 0)
         finally:
             ca.caput("{}:FEEDRATE".format(brick_pv_root), 100, wait=True)

--- a/test/test_pmac/test_system/trajectories.py
+++ b/test/test_pmac/test_system/trajectories.py
@@ -55,10 +55,10 @@ def trajectory_quick_scan(test, test_brick):
     while test_brick.height.moving:
         Sleep(0.01)  # allow deceleration todo need to put this in the driver itself
 
-    test.assertEquals(test_brick.m1.pos, rows[-1])
-    test.assertEquals(test_brick.m2.pos, cols[-1])
-    test.assertEquals(test_brick.height.pos, heights[-1])
-    test.assertEquals(test_brick.angle.pos, angles[-1])
+    test.assertEqual(test_brick.m1.pos, rows[-1])
+    test.assertEqual(test_brick.m2.pos, cols[-1])
+    test.assertEqual(test_brick.height.pos, heights[-1])
+    test.assertEqual(test_brick.angle.pos, angles[-1])
 
 
 def trajectory_fast_scan(


### PR DESCRIPTION
This PR is related to the working in progress to remove the velocities calculation from the motion program, and bring it to the driver level.

Some points that still need to be addressed, some of them discussed with @coretl , @ajgdls  and  @JimboMonkey :

- [x] Fix white spaces to make it clear where are the changes
- [x] Implement the velocities calculation in the driver level instead of in motion program
  - [x] Rollback appendVelMode/appendVelArray to append
  - [x] Substitute VelType for CalcVel, and remove from the broker
  - [x] Set CalcVel using asyn
  - [x] Port the equations from the motion program
- [x] Stop sending the VelMode
- [x] Update motion programs removing the velocities calculations (and correspondent subprograms)
- [x] Update the memory buffer
- [x] Bump motion program version
- [x] Update tests

If I'm missing something, please let me know.
