### PR TITLE
Arm ppmac driver fix

### DIFF
--- a/pmacApp/powerPmacAsynPortSrc/drvAsynPowerPMACPort.cpp
+++ b/pmacApp/powerPmacAsynPortSrc/drvAsynPowerPMACPort.cpp
@@ -87,6 +87,7 @@ asynCommonReport(void *drvPvt, FILE *fp, int details)
         fprintf(fp, "    Characters written: %lu\n", ssh->nWritten);
         fprintf(fp, "       Characters read: %lu\n", ssh->nRead);
     }
+    ssh->fd->report(fp);
 }
 
 /*
@@ -163,6 +164,9 @@ connectIt(void *drvPvt, asynUser *pasynUser)
     ssh->fd->write(gpascii_txt, strlen(gpascii_txt), &bytes, 1000);
     ssh->fd->read(buff, sizeof(buff), &bytes, '\n', 1000);
     ssh->fd->syncInteractive("#\n", "\006");
+
+    // Finally turn on error checking in the driver
+    ssh->fd->setErrorChecking(true);
 
     asynPrint(pasynUser, ASYN_TRACE_FLOW, "Opened connection to %s\n", ssh->SSHDeviceName);
     return asynSuccess;

--- a/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
+++ b/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
@@ -273,16 +273,23 @@ SSHDriverStatus SSHDriver::connectSSH()
   // Here we should wait for the initial welcome line
   char buffer[1024];
   size_t bytes = 0;
+  printf("1A\n");
   read(buffer, 512, &bytes, 0x06, 100, false);
+  buffer[bytes] = 0;
+  printf("Buffer: %s\n", buffer);
+  printf("1B\n");
 
   const char *ps1_last_txt = "!?%#";
   for (unsigned int i=0; i <strlen(ps1_last_txt); i++)
   {
+  printf("1C\n");
     // Set the prompt and read it back
     sprintf(buffer, "PS1=%c\n", ps1_last_txt[i]);
 
     write(buffer, strlen(buffer), &bytes, 1000);
+  printf("1D\n");
     read(buffer, 512, &bytes, ps1_last_txt[i], 3000, false);
+  printf("1E\n");
     buffer[bytes] = '\0';
   }
   printf("Completed PS1=!?%#\n");

--- a/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
+++ b/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
@@ -527,9 +527,10 @@ SSHDriverStatus SSHDriver::write(const char *buffer, size_t bufferSize, size_t *
  *
  * @param buffer - A string buffer to hold the read data.
  * @param bufferSize - The maximum number of bytes to read.
- * @param bytesWritten - The number of bytes that have been read.
+ * @param bytesRead - The number of bytes that have been read.
  * @param readTerm - A terminator to use as a check for EOM (End Of Message).
  * @param timeout - A timeout in ms for the read.
+ * @param crlf - Boolean. If true then match against the terminator followed by CRLF.
  * @return - Success or failure.
  */
 SSHDriverStatus SSHDriver::read(char *buffer, size_t bufferSize, size_t *bytesRead, int readTerm, int timeout, bool crlf)

--- a/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
+++ b/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
@@ -429,7 +429,7 @@ SSHDriverStatus SSHDriver::write(const char *buffer, size_t bufferSize, size_t *
     *bytesWritten = rc;
   } else {
     debugPrint("%s : No bytes were written, libssh2 error (%d)\n", functionName, rc);
-    bytesWritten = 0;
+    *bytesWritten = 0;
     return SSHDriverError;
   }
 

--- a/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
+++ b/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
@@ -269,6 +269,7 @@ SSHDriverStatus SSHDriver::connectSSH()
 
   setBlocking(0);
 
+  printf("Connected, calling PS1=!?%#\n");
   // Here we should wait for the initial welcome line
   char buffer[1024];
   size_t bytes = 0;
@@ -284,9 +285,11 @@ SSHDriverStatus SSHDriver::connectSSH()
     read(buffer, 512, &bytes, ps1_last_txt[i], 3000, false);
     buffer[bytes] = '\0';
   }
+  printf("Completed PS1=!?%#\n");
   /* Read the final '\n' */
   read(buffer, 512, &bytes, '\n', 100, false);
   debugPrint("%s : Connection ready...\n", functionName);
+  printf("Final read after connection\n");
 
   return SSHDriverSuccess;
 }
@@ -593,6 +596,8 @@ SSHDriverStatus SSHDriver::syncInteractive(const char *snd_str,  const char *exp
   size_t bytes = 0;
   SSHDriverStatus status = SSHDriverError;
 
+  printf("Starting syncInteractive\n");
+
   debugPrint("%s : Method called exp_str => ", functionName);
   debugStrPrintEscapedNL(exp_str, exp_str_len);
 
@@ -613,6 +618,9 @@ SSHDriverStatus SSHDriver::syncInteractive(const char *snd_str,  const char *exp
       return status;
     }
   }
+
+  printf("Exiting syncInteractive\n");
+
   return SSHDriverError;
 }
 

--- a/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
+++ b/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
@@ -369,15 +369,20 @@ SSHDriverStatus SSHDriver::flush()
     return SSHDriverError;
   }
 
-  int rc = libssh2_channel_flush_ex(channel_, 0);
-  rc |= libssh2_channel_flush_ex(channel_, 1);
-  rc |= libssh2_channel_flush_ex(channel_, 2);
+  // Call the underlying libssh2 flush for all channel streams
+  int rc = libssh2_channel_flush_ex(channel_, LIBSSH2_CHANNEL_FLUSH_ALL);
+  if (rc < 0){
+    debugPrint("Flush: libssh2_channel_flush_ex failed with error code %d\n", rc);
+    return SSHDriverError;
+  }
+  // Read out any remaining bytes from t he channel
   rc = libssh2_channel_read(channel_, buff, 2048);
   if (rc > 0){
     debugPrint("Flushed %d bytes\n", rc);
   }
 
   if (rc < 0){
+    debugPrint("Flush: libssh2_channel_read failed with error code %d\n", rc);
     return SSHDriverError;
   }
   return SSHDriverSuccess;

--- a/pmacApp/powerPmacAsynPortSrc/sshDriver.h
+++ b/pmacApp/powerPmacAsynPortSrc/sshDriver.h
@@ -30,6 +30,8 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#include <fstream>
+
 typedef enum e_SSHDriverStatus
 {
   SSHDriverSuccess,
@@ -52,11 +54,13 @@ class SSHDriver {
     SSHDriverStatus setPassword(const char *password);
     SSHDriverStatus connectSSH();
     SSHDriverStatus flush();
+    SSHDriverStatus setErrorChecking(bool error_check);
     SSHDriverStatus write(const char *buffer, size_t bufferSize, size_t *bytesWritten, int timeout);
-    SSHDriverStatus read(char *buffer, size_t bufferSize, size_t *bytesRead, int readTerm, int timeout);
+    SSHDriverStatus read(char *buffer, size_t bufferSize, size_t *bytesRead, int readTerm, int timeout, bool crlf=true);
     SSHDriverStatus syncInteractive(const char *snd_str,  const char *exp_str);
     SSHDriverStatus disconnectSSH();
     virtual ~SSHDriver();
+    SSHDriverStatus report(FILE *fp);
 
   private:
     int sock_;
@@ -72,6 +76,10 @@ class SSHDriver {
 
     SSHDriverStatus setBlocking(int blocking);
 
+    bool error_checking_;
+    int potential_errors_;
+    int caught_errors_;
+    int caught_delays_;
 };
 
 

--- a/pmacApp/src/pmacMessageBroker.cpp
+++ b/pmacApp/src/pmacMessageBroker.cpp
@@ -51,7 +51,7 @@ asynStatus pmacMessageBroker::connect(const char *port, int addr) {
   debug(DEBUG_FLOW, functionName, "Connecting to low level asynOctetSyncIO port", port);
 
   //Connect our Asyn user to the low level port that is a parameter to this constructor
-  status = lowLevelPortConnect(port, addr, &lowLevelPortUser_, (char *) "\006", (char *) "\r");
+  status = lowLevelPortConnect(port, addr, &lowLevelPortUser_, (char *) "\006", (char *) "\n");
   if (status != asynSuccess) {
     debug(DEBUG_ERROR, functionName, "Failed to connect to low level asynOctetSyncIO port", port);
   }


### PR DESCRIPTION
Fix a problem with the PowerPMAC driver that is exposed by the Arm version of the motion controller.  In this version it is possible for messages to arrive without the trailing characters (CR LF) after the command terminator (BELL).  This would mean that the next command echo is prefixed with those characters and corresponding status updates could become out of sync.
The driver has been improved to ensure that these extra characters are checked for and the driver blocks until they are received (or a timeout occurs).  In reality they always arrive within a ms or so.
Some additional debugging log messages have been added.

There are some additional updates planned to improve this driver further, but this is a functional fix for the problem described above.