### PR TITLE
Improve CPU load calculation

### DIFF
--- a/pmacApp/Db/pmacController.template
+++ b/pmacApp/Db/pmacController.template
@@ -235,10 +235,6 @@ record(ai, "$(P):CPUNUMCORES") {
   field(DTYP, "asynInt32")
   field(SCAN, "I/O Intr")
   field(INP, "@asyn($(PORT),0)PMAC_C_CPU_NUM_CORES")
-  field(HIGH, "4")
-  field(HSV, "MINOR")
-  field(LOW, "1")
-  field(LSV, "MAJOR")
 }
 
 # % archiver 10 Monitor

--- a/pmacApp/Db/pmacController.template
+++ b/pmacApp/Db/pmacController.template
@@ -235,6 +235,10 @@ record(ai, "$(P):CPUNUMCORES") {
   field(DTYP, "asynInt32")
   field(SCAN, "I/O Intr")
   field(INP, "@asyn($(PORT),0)PMAC_C_CPU_NUM_CORES")
+  field(HIGH, "4")
+  field(HSV, "MINOR")
+  field(LOW, "1")
+  field(LSV, "MAJOR")
 }
 
 # % archiver 10 Monitor

--- a/pmacApp/Db/pmacController.template
+++ b/pmacApp/Db/pmacController.template
@@ -229,13 +229,66 @@ record(mbbi, "$(P):PMACTYPE") {
   field(INP, "@asyn($(PORT),0)PMAC_VIM_cid")
 }
 
+# pmac number of CPU cores
+record(ai, "$(P):CPUNUMCORES") {
+  field(DESC, "Number of CPU cores")
+  field(DTYP, "asynInt32")
+  field(SCAN, "I/O Intr")
+  field(INP, "@asyn($(PORT),0)PMAC_C_CPU_NUM_CORES")
+}
+
 # % archiver 10 Monitor
 # This makes the component icon reflect the severity
 # % gui, $(PORT), sevr
-record(ai, "$(P):CPULOAD") {
+record(ai, "$(P):CPULOAD_0") {
   field(DTYP, "asynFloat64")
   field(SCAN, "I/O Intr")
-  field(INP, "@asyn($(PORT),0)PMAC_C_CPU_USAGE")
+  field(INP, "@asyn($(PORT),0)PMAC_C_CPU_USAGE_0")
+  field(PREC, "2")
+  field(EGU, "%")
+  field(HIGH, "60")
+  field(HSV, "MINOR")
+  field(HIHI, "80")
+  field(HHSV, "MAJOR")
+}
+
+# % archiver 10 Monitor
+# This makes the component icon reflect the severity
+# % gui, $(PORT), sevr
+record(ai, "$(P):CPULOAD_1") {
+  field(DTYP, "asynFloat64")
+  field(SCAN, "I/O Intr")
+  field(INP, "@asyn($(PORT),0)PMAC_C_CPU_USAGE_1")
+  field(PREC, "2")
+  field(EGU, "%")
+  field(HIGH, "60")
+  field(HSV, "MINOR")
+  field(HIHI, "80")
+  field(HHSV, "MAJOR")
+}
+
+# % archiver 10 Monitor
+# This makes the component icon reflect the severity
+# % gui, $(PORT), sevr
+record(ai, "$(P):CPULOAD_2") {
+  field(DTYP, "asynFloat64")
+  field(SCAN, "I/O Intr")
+  field(INP, "@asyn($(PORT),0)PMAC_C_CPU_USAGE_2")
+  field(PREC, "2")
+  field(EGU, "%")
+  field(HIGH, "60")
+  field(HSV, "MINOR")
+  field(HIHI, "80")
+  field(HHSV, "MAJOR")
+}
+
+# % archiver 10 Monitor
+# This makes the component icon reflect the severity
+# % gui, $(PORT), sevr
+record(ai, "$(P):CPULOAD_3") {
+  field(DTYP, "asynFloat64")
+  field(SCAN, "I/O Intr")
+  field(INP, "@asyn($(PORT),0)PMAC_C_CPU_USAGE_3")
   field(PREC, "2")
   field(EGU, "%")
   field(HIGH, "60")

--- a/pmacApp/opi/edl/pmacController.edl
+++ b/pmacApp/opi/edl/pmacController.edl
@@ -3,10 +3,10 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 1961
-y 265
+x 513
+y 64
 w 575
-h 970
+h 955
 font "arial-medium-r-16.0"
 ctlFont "arial-bold-r-16.0"
 btnFont "arial-medium-r-16.0"
@@ -23,8 +23,101 @@ title "$(pmac)"
 showGrid
 snapToGrid
 gridSize 5
-disableScroll
 endScreenProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 765
+w 305
+h 135
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 775
+w 305
+h 125
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 780
+w 135
+h 20
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Response (ECHO)"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 265
+y 765
+w 97
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  PMAC Settings  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 415
+y 780
+w 145
+h 20
+controlPv "$(pmac):READ_ECHO"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):PMACTYPE"
+visMin "0"
+visMax "1"
+endObjectProperties
 
 # (Rectangle)
 object activeRectangleClass
@@ -35,7 +128,7 @@ release 0
 x 5
 y 130
 w 565
-h 75
+h 50
 lineColor index 14
 fill
 fillColor index 5
@@ -248,7 +341,7 @@ major 4
 minor 0
 release 0
 x 265
-y 790
+y 765
 w 305
 h 135
 
@@ -261,101 +354,7 @@ major 4
 minor 0
 release 0
 x 265
-y 800
-w 305
-h 125
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 805
-w 135
-h 20
-font "arial-bold-r-14.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "Response (ECHO)"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 265
-y 790
-w 97
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  PMAC Settings  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 415
-y 805
-w 145
-h 20
-controlPv "$(pmac):READ_ECHO"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-endGroup
-
-visPv "$(pmac):PMACTYPE"
-visMin "0"
-visMax "1"
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 790
-w 305
-h 135
-
-beginGroup
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 800
+y 775
 w 305
 h 125
 lineColor index 14
@@ -370,7 +369,7 @@ major 4
 minor 6
 release 0
 x 445
-y 880
+y 855
 w 120
 h 12
 controlPv "$(pmac):VME_ADDR_MODE"
@@ -392,7 +391,7 @@ major 4
 minor 1
 release 1
 x 270
-y 880
+y 855
 w 126
 h 11
 font "arial-medium-r-10.0"
@@ -412,7 +411,7 @@ major 4
 minor 1
 release 1
 x 270
-y 895
+y 870
 w 117
 h 11
 font "arial-medium-r-10.0"
@@ -432,7 +431,7 @@ major 4
 minor 6
 release 0
 x 445
-y 895
+y 870
 w 120
 h 12
 controlPv "$(pmac):VME_INTLVL"
@@ -454,7 +453,7 @@ major 4
 minor 1
 release 1
 x 270
-y 805
+y 780
 w 118
 h 11
 font "arial-medium-r-10.0"
@@ -474,7 +473,7 @@ major 4
 minor 6
 release 0
 x 445
-y 805
+y 780
 w 120
 h 12
 controlPv "$(pmac):PLC_CONTROL"
@@ -497,7 +496,7 @@ major 4
 minor 6
 release 0
 x 445
-y 835
+y 810
 w 120
 h 12
 controlPv "$(pmac):ERRREPMODE"
@@ -519,7 +518,7 @@ major 4
 minor 6
 release 0
 x 445
-y 820
+y 795
 w 120
 h 12
 controlPv "$(pmac):IO_HANDSHAKE"
@@ -541,7 +540,7 @@ major 4
 minor 1
 release 1
 x 270
-y 820
+y 795
 w 123
 h 11
 font "arial-medium-r-10.0"
@@ -561,7 +560,7 @@ major 4
 minor 1
 release 1
 x 270
-y 835
+y 810
 w 119
 h 11
 font "arial-medium-r-10.0"
@@ -581,7 +580,7 @@ major 4
 minor 6
 release 0
 x 445
-y 850
+y 825
 w 120
 h 12
 controlPv "$(pmac):DPRAM_COMMS_INT"
@@ -603,7 +602,7 @@ major 4
 minor 6
 release 0
 x 445
-y 865
+y 840
 w 120
 h 12
 controlPv "$(pmac):DPRAM_COMMS"
@@ -625,7 +624,7 @@ major 4
 minor 1
 release 1
 x 270
-y 865
+y 840
 w 129
 h 11
 font "arial-medium-r-10.0"
@@ -645,7 +644,7 @@ major 4
 minor 1
 release 1
 x 270
-y 850
+y 825
 w 173
 h 11
 font "arial-medium-r-10.0"
@@ -665,7 +664,7 @@ major 4
 minor 1
 release 1
 x 265
-y 790
+y 765
 w 97
 h 13
 font "arial-medium-r-12.0"
@@ -686,7 +685,7 @@ major 4
 minor 6
 release 0
 x 445
-y 910
+y 885
 w 120
 h 12
 controlPv "$(pmac):VME_DPRAMBASE"
@@ -709,7 +708,7 @@ major 4
 minor 1
 release 1
 x 270
-y 910
+y 885
 w 153
 h 11
 font "arial-medium-r-10.0"
@@ -736,7 +735,7 @@ major 4
 minor 1
 release 0
 x 460
-y 935
+y 915
 w 110
 h 25
 fgColor index 46
@@ -746,198 +745,6 @@ botShadowColor index 11
 label "EXIT"
 font "arial-medium-r-18.0"
 3d
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 555
-w 250
-h 130
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 550
-w 63
-h 13
-font "arial-medium-r-12.0"
-fgColor index 14
-bgColor index 8
-value {
-  "  Feedrate  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Textentry)
-object TextentryClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 180
-y 650
-w 70
-h 20
-controlPv "$(pmac):FEEDRATE_LIMIT"
-displayMode "decimal"
-precision 2
-fgColor index 25
-fgAlarm
-bgColor index 3
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 650
-w 155
-h 20
-font "arial-medium-r-12.0"
-fgColor index 14
-bgColor index 10
-useDisplayBg
-value {
-  "Minimum allowed"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 600
-w 160
-h 20
-font "arial-medium-r-12.0"
-fgColor index 14
-bgColor index 10
-useDisplayBg
-value {
-  "Set feedrate for all CS"
-}
-endObjectProperties
-
-# (Textentry)
-object TextentryClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 180
-y 600
-w 70
-h 20
-controlPv "$(pmac):FEEDRATE"
-displayMode "decimal"
-precision 2
-fgColor index 25
-fgAlarm
-bgColor index 3
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 180
-y 625
-w 70
-h 20
-controlPv "$(pmac):FEEDRATE_RBV"
-displayMode "decimal"
-precision 2
-fgColor index 15
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 625
-w 160
-h 20
-font "arial-medium-r-12.0"
-fgColor index 14
-bgColor index 10
-useDisplayBg
-value {
-  "Current lowest feedrate"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 575
-w 160
-h 20
-font "arial-medium-r-12.0"
-fgColor index 14
-bgColor index 10
-useDisplayBg
-value {
-  "Feedrate problem:"
-}
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 235
-y 575
-w 15
-h 15
-controlPv "$(pmac):FEEDRATE_PROBLEM_RBV"
-lineColor index 14
-onColor index 20
-offColor index 24
-lineWidth 2
-numBits 1
 endObjectProperties
 
 # (Static Text)
@@ -961,313 +768,6 @@ autoSize
 border
 endObjectProperties
 
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 175
-w 85
-h 30
-font "arial-bold-r-14.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "CPU Load:"
-}
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 340
-y 165
-w 100
-h 35
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 340
-y 165
-w 42
-h 13
-font "courier-bold-r-12.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Core 3"
-}
-autoSize
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 340
-y 180
-w 75
-h 20
-controlPv "$(pmac):CPULOAD_3"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-endGroup
-
-visPv "$(pmac):CPUNUMCORES"
-visMin "4"
-visMax "5"
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 260
-y 165
-w 100
-h 35
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 260
-y 165
-w 42
-h 13
-font "courier-bold-r-12.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Core 2"
-}
-autoSize
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 260
-y 180
-w 75
-h 20
-controlPv "$(pmac):CPULOAD_2"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-endGroup
-
-visPv "$(pmac):CPUNUMCORES"
-visMin "3"
-visMax "5"
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 180
-y 165
-w 100
-h 35
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 180
-y 165
-w 42
-h 13
-font "courier-bold-r-12.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Core 1"
-}
-autoSize
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 180
-y 180
-w 75
-h 20
-controlPv "$(pmac):CPULOAD_1"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-endGroup
-
-visPv "$(pmac):CPUNUMCORES"
-visMin "2"
-visMax "5"
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 100
-y 165
-w 100
-h 35
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 100
-y 165
-w 42
-h 13
-font "courier-bold-r-12.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Core 0"
-}
-autoSize
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 100
-y 180
-w 75
-h 20
-controlPv "$(pmac):CPULOAD_0"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-endGroup
-
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 10
-y 135
-w 245
-h 30
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 135
-w 85
-h 30
-font "arial-bold-r-14.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "CPU Cores:"
-}
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 100
-y 140
-w 155
-h 20
-controlPv "$(pmac):CPUNUMCORES"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-endGroup
-
-endObjectProperties
-
 # (Group)
 object activeGroupClass
 beginObjectProperties
@@ -1275,7 +775,7 @@ major 4
 minor 0
 release 0
 x 5
-y 210
+y 190
 w 565
 h 220
 
@@ -1288,7 +788,7 @@ major 4
 minor 0
 release 0
 x 5
-y 220
+y 200
 w 565
 h 210
 
@@ -1301,7 +801,7 @@ major 4
 minor 0
 release 0
 x 5
-y 220
+y 200
 w 565
 h 210
 lineColor index 14
@@ -1316,7 +816,7 @@ major 4
 minor 0
 release 0
 x 15
-y 230
+y 210
 w 130
 h 192
 
@@ -1329,7 +829,7 @@ major 4
 minor 0
 release 0
 x 15
-y 230
+y 210
 w 12
 h 192
 controlPv "$(pmac):CTRLSTAT:status1"
@@ -1346,7 +846,7 @@ major 4
 minor 1
 release 1
 x 30
-y 411
+y 391
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1366,7 +866,7 @@ major 4
 minor 1
 release 1
 x 30
-y 399
+y 379
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1386,7 +886,7 @@ major 4
 minor 1
 release 1
 x 30
-y 387
+y 367
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1406,7 +906,7 @@ major 4
 minor 1
 release 1
 x 30
-y 375
+y 355
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1426,7 +926,7 @@ major 4
 minor 1
 release 1
 x 30
-y 363
+y 343
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1446,7 +946,7 @@ major 4
 minor 1
 release 1
 x 30
-y 351
+y 331
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1466,7 +966,7 @@ major 4
 minor 1
 release 1
 x 30
-y 339
+y 319
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1486,7 +986,7 @@ major 4
 minor 1
 release 1
 x 30
-y 327
+y 307
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1506,7 +1006,7 @@ major 4
 minor 1
 release 1
 x 30
-y 315
+y 295
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1526,7 +1026,7 @@ major 4
 minor 1
 release 1
 x 30
-y 303
+y 283
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1546,7 +1046,7 @@ major 4
 minor 1
 release 1
 x 30
-y 291
+y 271
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1566,7 +1066,7 @@ major 4
 minor 1
 release 1
 x 30
-y 279
+y 259
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1586,7 +1086,7 @@ major 4
 minor 1
 release 1
 x 30
-y 267
+y 247
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1606,7 +1106,7 @@ major 4
 minor 1
 release 1
 x 30
-y 255
+y 235
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1626,7 +1126,7 @@ major 4
 minor 1
 release 1
 x 30
-y 243
+y 223
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1646,7 +1146,7 @@ major 4
 minor 1
 release 1
 x 30
-y 231
+y 211
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1670,7 +1170,7 @@ major 4
 minor 0
 release 0
 x 370
-y 230
+y 210
 w 189
 h 192
 
@@ -1683,7 +1183,7 @@ major 4
 minor 1
 release 1
 x 385
-y 411
+y 391
 w 138
 h 11
 font "arial-medium-r-10.0"
@@ -1703,7 +1203,7 @@ major 4
 minor 1
 release 1
 x 385
-y 399
+y 379
 w 138
 h 11
 font "arial-medium-r-10.0"
@@ -1723,7 +1223,7 @@ major 4
 minor 1
 release 1
 x 385
-y 387
+y 367
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1743,7 +1243,7 @@ major 4
 minor 1
 release 1
 x 385
-y 375
+y 355
 w 80
 h 11
 font "arial-medium-r-10.0"
@@ -1763,7 +1263,7 @@ major 4
 minor 1
 release 1
 x 385
-y 363
+y 343
 w 142
 h 11
 font "arial-medium-r-10.0"
@@ -1783,7 +1283,7 @@ major 4
 minor 1
 release 1
 x 385
-y 351
+y 331
 w 174
 h 11
 font "arial-medium-r-10.0"
@@ -1803,7 +1303,7 @@ major 4
 minor 1
 release 1
 x 385
-y 339
+y 319
 w 140
 h 11
 font "arial-medium-r-10.0"
@@ -1823,7 +1323,7 @@ major 4
 minor 1
 release 1
 x 385
-y 327
+y 307
 w 135
 h 11
 font "arial-medium-r-10.0"
@@ -1843,7 +1343,7 @@ major 4
 minor 1
 release 1
 x 385
-y 315
+y 295
 w 107
 h 11
 font "arial-medium-r-10.0"
@@ -1863,7 +1363,7 @@ major 4
 minor 1
 release 1
 x 385
-y 303
+y 283
 w 85
 h 11
 font "arial-medium-r-10.0"
@@ -1883,7 +1383,7 @@ major 4
 minor 1
 release 1
 x 385
-y 291
+y 271
 w 105
 h 11
 font "arial-medium-r-10.0"
@@ -1903,7 +1403,7 @@ major 4
 minor 1
 release 1
 x 385
-y 279
+y 259
 w 116
 h 11
 font "arial-medium-r-10.0"
@@ -1923,7 +1423,7 @@ major 4
 minor 1
 release 1
 x 385
-y 267
+y 247
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1943,7 +1443,7 @@ major 4
 minor 1
 release 1
 x 385
-y 255
+y 235
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1963,7 +1463,7 @@ major 4
 minor 1
 release 1
 x 385
-y 243
+y 223
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -1983,7 +1483,7 @@ major 4
 minor 1
 release 1
 x 385
-y 231
+y 211
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2003,7 +1503,7 @@ major 4
 minor 0
 release 0
 x 370
-y 230
+y 210
 w 12
 h 192
 controlPv "$(pmac):CTRLSTAT:status2"
@@ -2031,7 +1531,7 @@ major 4
 minor 0
 release 0
 x 5
-y 210
+y 190
 w 565
 h 220
 
@@ -2044,7 +1544,7 @@ major 4
 minor 0
 release 0
 x 5
-y 220
+y 200
 w 565
 h 210
 lineColor index 14
@@ -2059,7 +1559,7 @@ major 4
 minor 1
 release 1
 x 5
-y 210
+y 190
 w 87
 h 13
 font "arial-medium-r-12.0"
@@ -2080,7 +1580,7 @@ major 4
 minor 0
 release 0
 x 15
-y 230
+y 210
 w 507
 h 193
 
@@ -2093,7 +1593,7 @@ major 4
 minor 1
 release 1
 x 31
-y 410
+y 390
 w 125
 h 11
 font "arial-medium-r-10.0"
@@ -2113,7 +1613,7 @@ major 4
 minor 1
 release 1
 x 31
-y 398
+y 378
 w 136
 h 11
 font "arial-medium-r-10.0"
@@ -2133,7 +1633,7 @@ major 4
 minor 1
 release 1
 x 31
-y 386
+y 366
 w 50
 h 11
 font "arial-medium-r-10.0"
@@ -2153,7 +1653,7 @@ major 4
 minor 1
 release 1
 x 31
-y 374
+y 354
 w 64
 h 11
 font "arial-medium-r-10.0"
@@ -2173,7 +1673,7 @@ major 4
 minor 1
 release 1
 x 31
-y 362
+y 342
 w 111
 h 11
 font "arial-medium-r-10.0"
@@ -2193,7 +1693,7 @@ major 4
 minor 1
 release 1
 x 31
-y 350
+y 330
 w 133
 h 11
 font "arial-medium-r-10.0"
@@ -2213,7 +1713,7 @@ major 4
 minor 1
 release 1
 x 31
-y 338
+y 318
 w 129
 h 11
 font "arial-medium-r-10.0"
@@ -2233,7 +1733,7 @@ major 4
 minor 1
 release 1
 x 31
-y 326
+y 306
 w 74
 h 11
 font "arial-medium-r-10.0"
@@ -2253,7 +1753,7 @@ major 4
 minor 1
 release 1
 x 31
-y 314
+y 294
 w 67
 h 11
 font "arial-medium-r-10.0"
@@ -2273,7 +1773,7 @@ major 4
 minor 1
 release 1
 x 31
-y 302
+y 282
 w 127
 h 11
 font "arial-medium-r-10.0"
@@ -2293,7 +1793,7 @@ major 4
 minor 1
 release 1
 x 31
-y 290
+y 270
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2313,7 +1813,7 @@ major 4
 minor 1
 release 1
 x 31
-y 278
+y 258
 w 134
 h 11
 font "arial-medium-r-10.0"
@@ -2333,7 +1833,7 @@ major 4
 minor 1
 release 1
 x 31
-y 266
+y 246
 w 53
 h 11
 font "arial-medium-r-10.0"
@@ -2353,7 +1853,7 @@ major 4
 minor 1
 release 1
 x 31
-y 254
+y 234
 w 73
 h 11
 font "arial-medium-r-10.0"
@@ -2373,7 +1873,7 @@ major 4
 minor 0
 release 0
 x 15
-y 230
+y 210
 w 12
 h 192
 controlPv "$(pmac):CTRLSTAT:status1"
@@ -2390,7 +1890,7 @@ major 4
 minor 1
 release 1
 x 31
-y 242
+y 222
 w 127
 h 11
 font "arial-medium-r-10.0"
@@ -2410,7 +1910,7 @@ major 4
 minor 1
 release 1
 x 31
-y 230
+y 210
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2430,7 +1930,7 @@ major 4
 minor 0
 release 0
 x 185
-y 230
+y 210
 w 337
 h 193
 
@@ -2443,7 +1943,7 @@ major 4
 minor 1
 release 1
 x 201
-y 410
+y 390
 w 67
 h 11
 font "arial-medium-r-10.0"
@@ -2463,7 +1963,7 @@ major 4
 minor 1
 release 1
 x 201
-y 398
+y 378
 w 76
 h 11
 font "arial-medium-r-10.0"
@@ -2483,7 +1983,7 @@ major 4
 minor 1
 release 1
 x 201
-y 386
+y 366
 w 113
 h 11
 font "arial-medium-r-10.0"
@@ -2503,7 +2003,7 @@ major 4
 minor 1
 release 1
 x 201
-y 374
+y 354
 w 87
 h 11
 font "arial-medium-r-10.0"
@@ -2523,7 +2023,7 @@ major 4
 minor 1
 release 1
 x 201
-y 362
+y 342
 w 122
 h 11
 font "arial-medium-r-10.0"
@@ -2543,7 +2043,7 @@ major 4
 minor 1
 release 1
 x 201
-y 350
+y 330
 w 72
 h 11
 font "arial-medium-r-10.0"
@@ -2563,7 +2063,7 @@ major 4
 minor 1
 release 1
 x 201
-y 338
+y 318
 w 54
 h 11
 font "arial-medium-r-10.0"
@@ -2583,7 +2083,7 @@ major 4
 minor 1
 release 1
 x 201
-y 326
+y 306
 w 69
 h 11
 font "arial-medium-r-10.0"
@@ -2603,7 +2103,7 @@ major 4
 minor 1
 release 1
 x 201
-y 314
+y 294
 w 92
 h 11
 font "arial-medium-r-10.0"
@@ -2623,7 +2123,7 @@ major 4
 minor 1
 release 1
 x 201
-y 302
+y 282
 w 90
 h 11
 font "arial-medium-r-10.0"
@@ -2643,7 +2143,7 @@ major 4
 minor 1
 release 1
 x 201
-y 290
+y 270
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2663,7 +2163,7 @@ major 4
 minor 1
 release 1
 x 201
-y 278
+y 258
 w 93
 h 11
 font "arial-medium-r-10.0"
@@ -2683,7 +2183,7 @@ major 4
 minor 1
 release 1
 x 201
-y 266
+y 246
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2703,7 +2203,7 @@ major 4
 minor 1
 release 1
 x 201
-y 242
+y 222
 w 119
 h 11
 font "arial-medium-r-10.0"
@@ -2723,7 +2223,7 @@ major 4
 minor 1
 release 1
 x 201
-y 230
+y 210
 w 89
 h 11
 font "arial-medium-r-10.0"
@@ -2743,7 +2243,7 @@ major 4
 minor 0
 release 0
 x 185
-y 230
+y 210
 w 12
 h 192
 controlPv "$(pmac):CTRLSTAT:status2"
@@ -2760,7 +2260,7 @@ major 4
 minor 1
 release 1
 x 201
-y 254
+y 234
 w 162
 h 11
 font "arial-medium-r-10.0"
@@ -2780,7 +2280,7 @@ major 4
 minor 0
 release 0
 x 370
-y 230
+y 210
 w 152
 h 193
 
@@ -2793,7 +2293,7 @@ major 4
 minor 1
 release 1
 x 385
-y 411
+y 391
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2813,7 +2313,7 @@ major 4
 minor 1
 release 1
 x 385
-y 398
+y 378
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2833,7 +2333,7 @@ major 4
 minor 1
 release 1
 x 385
-y 386
+y 366
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2853,7 +2353,7 @@ major 4
 minor 1
 release 1
 x 385
-y 374
+y 354
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2873,7 +2373,7 @@ major 4
 minor 1
 release 1
 x 385
-y 362
+y 342
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2893,7 +2393,7 @@ major 4
 minor 1
 release 1
 x 385
-y 350
+y 330
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2913,7 +2413,7 @@ major 4
 minor 1
 release 1
 x 385
-y 338
+y 318
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2933,7 +2433,7 @@ major 4
 minor 1
 release 1
 x 385
-y 326
+y 306
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2953,7 +2453,7 @@ major 4
 minor 1
 release 1
 x 385
-y 314
+y 294
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2973,7 +2473,7 @@ major 4
 minor 1
 release 1
 x 385
-y 302
+y 282
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -2993,7 +2493,7 @@ major 4
 minor 1
 release 1
 x 385
-y 290
+y 270
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -3013,7 +2513,7 @@ major 4
 minor 1
 release 1
 x 385
-y 278
+y 258
 w 115
 h 11
 font "arial-medium-r-10.0"
@@ -3033,7 +2533,7 @@ major 4
 minor 1
 release 1
 x 385
-y 266
+y 246
 w 75
 h 11
 font "arial-medium-r-10.0"
@@ -3053,7 +2553,7 @@ major 4
 minor 1
 release 1
 x 385
-y 254
+y 234
 w 137
 h 11
 font "arial-medium-r-10.0"
@@ -3073,7 +2573,7 @@ major 4
 minor 1
 release 1
 x 385
-y 242
+y 222
 w 81
 h 11
 font "arial-medium-r-10.0"
@@ -3093,7 +2593,7 @@ major 4
 minor 1
 release 1
 x 385
-y 230
+y 210
 w 81
 h 11
 font "arial-medium-r-10.0"
@@ -3113,7 +2613,7 @@ major 4
 minor 0
 release 0
 x 370
-y 230
+y 210
 w 12
 h 192
 controlPv "$(pmac):CTRLSTAT:status3"
@@ -3149,7 +2649,7 @@ major 4
 minor 1
 release 1
 x 5
-y 210
+y 190
 w 125
 h 13
 font "arial-medium-r-12.0"
@@ -3177,7 +2677,7 @@ major 4
 minor 0
 release 0
 x 5
-y 445
+y 420
 w 250
 h 95
 
@@ -3190,7 +2690,7 @@ major 4
 minor 0
 release 0
 x 5
-y 455
+y 430
 w 250
 h 85
 lineColor index 14
@@ -3205,7 +2705,7 @@ major 4
 minor 1
 release 1
 x 5
-y 445
+y 420
 w 120
 h 13
 font "arial-medium-r-12.0"
@@ -3226,7 +2726,7 @@ major 4
 minor 4
 release 0
 x 140
-y 465
+y 440
 w 105
 h 25
 fgColor index 43
@@ -3249,7 +2749,7 @@ major 4
 minor 4
 release 0
 x 140
-y 500
+y 475
 w 105
 h 25
 fgColor index 43
@@ -3272,7 +2772,7 @@ major 4
 minor 4
 release 0
 x 20
-y 465
+y 440
 w 105
 h 25
 fgColor index 43
@@ -3295,7 +2795,7 @@ major 4
 minor 0
 release 0
 x 20
-y 500
+y 475
 w 105
 h 25
 fgColor index 43
@@ -3343,7 +2843,7 @@ major 4
 minor 0
 release 0
 x 265
-y 445
+y 420
 w 305
 h 110
 
@@ -3356,7 +2856,7 @@ major 4
 minor 0
 release 0
 x 265
-y 455
+y 430
 w 305
 h 100
 lineColor index 14
@@ -3371,7 +2871,7 @@ major 4
 minor 0
 release 0
 x 275
-y 465
+y 440
 w 285
 h 80
 
@@ -3384,7 +2884,7 @@ major 4
 minor 0
 release 0
 x 275
-y 465
+y 440
 w 285
 h 80
 
@@ -3397,7 +2897,7 @@ major 4
 minor 0
 release 0
 x 275
-y 465
+y 440
 w 285
 h 80
 
@@ -3410,7 +2910,7 @@ major 4
 minor 0
 release 0
 x 275
-y 510
+y 485
 w 285
 h 35
 
@@ -3423,7 +2923,7 @@ major 4
 minor 0
 release 0
 x 275
-y 525
+y 500
 w 285
 h 20
 controlPv "$(pmac):PLCDISBITS01"
@@ -3441,7 +2941,7 @@ major 4
 minor 1
 release 1
 x 275
-y 510
+y 485
 w 282
 h 10
 font "courier-bold-r-10.0"
@@ -3465,7 +2965,7 @@ major 4
 minor 0
 release 0
 x 275
-y 465
+y 440
 w 285
 h 35
 
@@ -3478,7 +2978,7 @@ major 4
 minor 0
 release 0
 x 275
-y 480
+y 455
 w 285
 h 20
 controlPv "$(pmac):PLCDISBITS00"
@@ -3496,7 +2996,7 @@ major 4
 minor 1
 release 1
 x 280
-y 465
+y 440
 w 276
 h 10
 font "courier-bold-r-10.0"
@@ -3532,7 +3032,7 @@ major 4
 minor 1
 release 1
 x 265
-y 445
+y 420
 w 96
 h 13
 font "arial-medium-r-12.0"
@@ -3557,7 +3057,7 @@ major 4
 minor 0
 release 0
 x 265
-y 565
+y 540
 w 305
 h 65
 
@@ -3570,7 +3070,7 @@ major 4
 minor 0
 release 0
 x 265
-y 575
+y 550
 w 305
 h 55
 lineColor index 14
@@ -3585,7 +3085,7 @@ major 4
 minor 1
 release 1
 x 265
-y 565
+y 540
 w 281
 h 13
 font "arial-medium-r-12.0"
@@ -3606,7 +3106,7 @@ major 4
 minor 0
 release 0
 x 275
-y 600
+y 575
 w 285
 h 20
 controlPv "$(pmac):PROGBITS"
@@ -3624,7 +3124,7 @@ major 4
 minor 1
 release 1
 x 280
-y 585
+y 560
 w 276
 h 10
 font "courier-bold-r-10.0"
@@ -3648,7 +3148,7 @@ major 4
 minor 0
 release 0
 x 265
-y 640
+y 615
 w 305
 h 65
 
@@ -3661,7 +3161,7 @@ major 4
 minor 0
 release 0
 x 265
-y 650
+y 625
 w 305
 h 55
 lineColor index 14
@@ -3676,7 +3176,7 @@ major 4
 minor 1
 release 1
 x 265
-y 640
+y 615
 w 144
 h 13
 font "arial-medium-r-12.0"
@@ -3697,7 +3197,7 @@ major 4
 minor 0
 release 0
 x 275
-y 675
+y 650
 w 285
 h 20
 controlPv "$(pmac):GPIO_INP_BITS"
@@ -3715,7 +3215,7 @@ major 4
 minor 1
 release 1
 x 280
-y 660
+y 635
 w 276
 h 10
 font "courier-bold-r-10.0"
@@ -3739,7 +3239,7 @@ major 4
 minor 0
 release 0
 x 265
-y 715
+y 690
 w 305
 h 65
 
@@ -3752,7 +3252,7 @@ major 4
 minor 0
 release 0
 x 265
-y 725
+y 700
 w 305
 h 55
 lineColor index 14
@@ -3767,7 +3267,7 @@ major 4
 minor 1
 release 1
 x 265
-y 715
+y 690
 w 154
 h 13
 font "arial-medium-r-12.0"
@@ -3788,7 +3288,7 @@ major 4
 minor 0
 release 0
 x 275
-y 750
+y 725
 w 285
 h 20
 controlPv "$(pmac):GPIO_OP_BITS"
@@ -3806,7 +3306,7 @@ major 4
 minor 1
 release 1
 x 280
-y 735
+y 710
 w 276
 h 10
 font "courier-bold-r-10.0"
@@ -3830,7 +3330,7 @@ major 4
 minor 0
 release 0
 x 5
-y 870
+y 845
 w 250
 h 55
 
@@ -3843,7 +3343,7 @@ major 4
 minor 0
 release 0
 x 5
-y 880
+y 855
 w 250
 h 45
 lineColor index 14
@@ -3858,7 +3358,7 @@ major 4
 minor 1
 release 1
 x 5
-y 870
+y 845
 w 197
 h 13
 font "arial-medium-r-12.0"
@@ -3879,7 +3379,7 @@ major 4
 minor 0
 release 0
 x 20
-y 890
+y 865
 w 220
 h 25
 fgColor index 14
@@ -3903,7 +3403,7 @@ major 4
 minor 0
 release 0
 x 5
-y 765
+y 740
 w 250
 h 95
 
@@ -3916,7 +3416,7 @@ major 4
 minor 0
 release 0
 x 5
-y 775
+y 750
 w 250
 h 85
 lineColor index 14
@@ -3931,7 +3431,7 @@ major 4
 minor 1
 release 0
 x 20
-y 790
+y 765
 w 220
 h 25
 fgColor index 21
@@ -3957,7 +3457,7 @@ major 4
 minor 1
 release 1
 x 5
-y 765
+y 740
 w 66
 h 13
 font "arial-medium-r-12.0"
@@ -3978,7 +3478,7 @@ major 4
 minor 1
 release 0
 x 20
-y 825
+y 800
 w 220
 h 25
 fgColor index 21
@@ -4008,7 +3508,7 @@ major 4
 minor 0
 release 0
 x 5
-y 695
+y 670
 w 250
 h 60
 
@@ -4021,7 +3521,7 @@ major 4
 minor 0
 release 0
 x 5
-y 700
+y 675
 w 250
 h 55
 lineColor index 14
@@ -4036,7 +3536,7 @@ major 4
 minor 0
 release 0
 x 20
-y 720
+y 695
 w 220
 h 25
 fgColor index 25
@@ -4058,7 +3558,7 @@ major 4
 minor 1
 release 1
 x 5
-y 695
+y 670
 w 95
 h 13
 font "arial-medium-r-12.0"
@@ -4343,6 +3843,525 @@ bgColor index 10
 fill
 font "arial-bold-r-14.0"
 fontAlign "center"
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 525
+w 250
+h 135
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 530
+w 250
+h 130
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 525
+w 63
+h 13
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 8
+value {
+  "  Feedrate  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 180
+y 625
+w 70
+h 20
+controlPv "$(pmac):FEEDRATE_LIMIT"
+displayMode "decimal"
+precision 2
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 625
+w 155
+h 20
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 10
+useDisplayBg
+value {
+  "Minimum allowed"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 575
+w 160
+h 20
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 10
+useDisplayBg
+value {
+  "Set feedrate for all CS"
+}
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 180
+y 575
+w 70
+h 20
+controlPv "$(pmac):FEEDRATE"
+displayMode "decimal"
+precision 2
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 180
+y 600
+w 70
+h 20
+controlPv "$(pmac):FEEDRATE_RBV"
+displayMode "decimal"
+precision 2
+fgColor index 15
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 600
+w 160
+h 20
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 10
+useDisplayBg
+value {
+  "Current lowest feedrate"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 550
+w 160
+h 20
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 10
+useDisplayBg
+value {
+  "Feedrate problem:"
+}
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 235
+y 550
+w 15
+h 15
+controlPv "$(pmac):FEEDRATE_PROBLEM_RBV"
+lineColor index 14
+onColor index 20
+offColor index 24
+lineWidth 2
+numBits 1
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 185
+y 145
+w 85
+h 30
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "CPU Load:"
+}
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 495
+y 135
+w 70
+h 35
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 495
+y 135
+w 42
+h 13
+font "courier-bold-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Core 3"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 495
+y 150
+w 70
+h 20
+controlPv "$(pmac):CPULOAD_3"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):CPUNUMCORES"
+visInvert
+visMin "0"
+visMax "4"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 420
+y 135
+w 70
+h 35
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 420
+y 135
+w 42
+h 13
+font "courier-bold-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Core 2"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 420
+y 150
+w 70
+h 20
+controlPv "$(pmac):CPULOAD_2"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):CPUNUMCORES"
+visInvert
+visMin "0"
+visMax "3"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 345
+y 135
+w 70
+h 35
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 345
+y 135
+w 42
+h 13
+font "courier-bold-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Core 1"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 345
+y 150
+w 70
+h 20
+controlPv "$(pmac):CPULOAD_1"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):CPUNUMCORES"
+visInvert
+visMin "0"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 270
+y 135
+w 70
+h 35
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 135
+w 42
+h 13
+font "courier-bold-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Core 0"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 270
+y 150
+w 70
+h 20
+controlPv "$(pmac):CPULOAD_0"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 10
+y 145
+w 165
+h 30
+
+beginGroup
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 100
+y 150
+w 75
+h 20
+controlPv "$(pmac):CPUNUMCORES"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 145
+w 85
+h 30
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "CPU Cores:"
+}
 endObjectProperties
 
 endGroup

--- a/pmacApp/opi/edl/pmacController.edl
+++ b/pmacApp/opi/edl/pmacController.edl
@@ -3,10 +3,10 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 997
-y 37
-w 584
-h 886
+x 1961
+y 265
+w 575
+h 970
 font "arial-medium-r-16.0"
 ctlFont "arial-bold-r-16.0"
 btnFont "arial-medium-r-16.0"
@@ -26,2395 +26,16 @@ gridSize 5
 disableScroll
 endScreenProperties
 
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 710
-w 305
-h 135
-
-beginGroup
-
 # (Rectangle)
 object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 720
-w 305
-h 125
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 725
-w 135
-h 20
-font "arial-bold-r-14.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "Response (ECHO)"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 265
-y 710
-w 97
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  PMAC Settings  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 415
-y 725
-w 145
-h 20
-controlPv "$(pmac):READ_ECHO"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-endGroup
-
-visPv "$(pmac):PMACTYPE"
-visMin "0"
-visMax "1"
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 710
-w 305
-h 135
-
-beginGroup
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 720
-w 305
-h 125
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 6
-release 0
-x 445
-y 800
-w 120
-h 12
-controlPv "$(pmac):VME_ADDR_MODE"
-font "arial-medium-r-10.0"
-fgColor index 16
-bgColor index 10
-limitsFromDb
-nullColor index 0
-useHexPrefix
-newPos
-objType "monitors"
-noExecuteClipMask
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 800
-w 126
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "VME Address Modifier (I90)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 815
-w 117
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "VME Interrupt Level (I95)"
-}
-autoSize
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 6
-release 0
-x 445
-y 815
-w 120
-h 12
-controlPv "$(pmac):VME_INTLVL"
-font "arial-medium-r-10.0"
-fgColor index 16
-bgColor index 10
-limitsFromDb
-nullColor index 0
-useHexPrefix
-newPos
-objType "monitors"
-noExecuteClipMask
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 725
-w 118
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "PLC Program Control (I5)"
-}
-autoSize
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 6
-release 0
-x 445
-y 725
-w 120
-h 12
-controlPv "$(pmac):PLC_CONTROL"
-font "arial-medium-r-10.0"
-fgColor index 16
-bgColor index 10
-autoHeight
-limitsFromDb
-nullColor index 0
-useHexPrefix
-newPos
-objType "monitors"
-noExecuteClipMask
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 6
-release 0
-x 445
-y 755
-w 120
-h 12
-controlPv "$(pmac):ERRREPMODE"
-font "arial-medium-r-10.0"
-fgColor index 16
-bgColor index 10
-limitsFromDb
-nullColor index 0
-useHexPrefix
-newPos
-objType "monitors"
-noExecuteClipMask
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 6
-release 0
-x 445
-y 740
-w 120
-h 12
-controlPv "$(pmac):IO_HANDSHAKE"
-font "arial-medium-r-10.0"
-fgColor index 16
-bgColor index 10
-limitsFromDb
-nullColor index 0
-useHexPrefix
-newPos
-objType "monitors"
-noExecuteClipMask
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 740
-w 123
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "I/O Handshake Control (I3)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 755
-w 119
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "Error Reporting Mode (I6)"
-}
-autoSize
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 6
-release 0
-x 445
-y 770
-w 120
-h 12
-controlPv "$(pmac):DPRAM_COMMS_INT"
-font "arial-medium-r-10.0"
-fgColor index 16
-bgColor index 10
-limitsFromDb
-nullColor index 0
-useHexPrefix
-newPos
-objType "monitors"
-noExecuteClipMask
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 6
-release 0
-x 445
-y 785
-w 120
-h 12
-controlPv "$(pmac):DPRAM_COMMS"
-font "arial-medium-r-10.0"
-fgColor index 16
-bgColor index 10
-limitsFromDb
-nullColor index 0
-useHexPrefix
-newPos
-objType "monitors"
-noExecuteClipMask
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 785
-w 129
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "DPRAM ASCII Comms (I58)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 770
-w 173
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "DPRAM ASCII Comms Interrupt (I56)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 265
-y 710
-w 97
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  PMAC Settings  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 6
-release 0
-x 445
-y 830
-w 120
-h 12
-controlPv "$(pmac):VME_DPRAMBASE"
-format "hex"
-font "arial-medium-r-10.0"
-fgColor index 16
-bgColor index 10
-limitsFromDb
-nullColor index 0
-useHexPrefix
-newPos
-objType "monitors"
-noExecuteClipMask
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 270
-y 830
-w 153
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "VME DPRAM Base Address (I97)"
-}
-autoSize
-endObjectProperties
-
-endGroup
-
-visPv "$(pmac):PMACTYPE"
-visMin "1"
-visMax "100"
-endObjectProperties
-
-# (Group)
-object activeGroupClass
 beginObjectProperties
 major 4
 minor 0
 release 0
 x 5
-y 145
+y 130
 w 565
-h 210
-
-beginGroup
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 145
-w 565
-h 210
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 15
-y 155
-w 130
-h 192
-
-beginGroup
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 15
-y 155
-w 12
-h 192
-controlPv "$(pmac):CTRLSTAT:status1"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 336
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 324
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 312
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 300
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 288
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 276
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 264
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 252
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 240
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 228
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 216
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 204
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 192
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 180
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 168
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 30
-y 156
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-endGroup
-
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 370
-y 155
-w 189
-h 192
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 336
-w 138
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Software watchdog fault bit 2"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 324
-w 138
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Software watchdog fault bit 1"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 312
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Power on/reset load fault"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 300
-w 80
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Project load error"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 288
-w 142
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Saved configuration load error"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 276
-w 174
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Hardware change detected since save"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 264
-w 140
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "System file configuration error"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 252
-w 135
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Factory default configuration"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 240
-w 107
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "No system clocks found"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 228
-w 85
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Abort all condition"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 216
-w 105
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Insufficient user buffer"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 204
-w 116
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Insufficient flash memory"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 192
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 180
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 168
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 156
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 370
-y 155
-w 12
-h 192
-controlPv "$(pmac):CTRLSTAT:status2"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endObjectProperties
-
-endGroup
-
-endObjectProperties
-
-endGroup
-
-visPv "$(pmac):PMACTYPE"
-visMin "0"
-visMax "1"
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 135
-w 565
-h 220
-
-beginGroup
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 145
-w 565
-h 210
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 135
-w 87
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  PMAC Status  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 15
-y 155
-w 507
-h 193
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 335
-w 125
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Illegal L variable definition"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 323
-w 136
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Real-Time Interrupt Warning"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 311
-w 50
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Flash error"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 299
-w 64
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "DPRAM error"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 287
-w 111
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "PROM checksum active"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 275
-w 133
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Any memory checksum error"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 263
-w 129
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Leadscrew compensation on"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 251
-w 74
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Watchdog timer"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 239
-w 67
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Servo Request"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 227
-w 127
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Data gather start on trigger"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 215
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 203
-w 134
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Data Gathering Function On"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 191
-w 53
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Servo Error"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 179
-w 73
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "CPU Type Bit 1"
-}
-autoSize
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 15
-y 155
-w 12
-h 192
-controlPv "$(pmac):CTRLSTAT:status1"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 167
-w 127
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Real-time interrupt re-entry"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 31
-y 155
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 185
-y 155
-w 337
-h 193
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 335
-w 67
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "UMAC System"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 323
-w 76
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "PLC buffer open"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 311
-w 113
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "ASCII rotary buffer open"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 299
-w 87
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Motion buffer open"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 287
-w 122
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Binary rotary buffers open"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 275
-w 72
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "CPU Type Bit 0"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 263
-w 54
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Turbo VME"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 251
-w 69
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Turbo Ultralite"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 239
-w 92
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "This card addressed"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 227
-w 90
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "All cards addressed"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 215
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 203
-w 93
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Phase clock missing"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 191
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "MACRO ring check error"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 167
-w 119
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "TWS variable parity error"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 155
-w 89
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Configuration error"
-}
-autoSize
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 185
-y 155
-w 12
-h 192
-controlPv "$(pmac):CTRLSTAT:status2"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 201
-y 179
-w 162
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "MACRO aux. communication error"
-}
-autoSize
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 370
-y 155
-w 152
-h 193
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 336
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 323
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 311
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 299
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 287
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 275
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 263
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 251
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 239
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 227
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 215
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 203
-w 115
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "(Reserved for future use)"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 191
-w 75
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Fixed buffer full"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 179
-w 137
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Ring master-to-master comms"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 167
-w 81
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Kinematics active"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 385
-y 155
-w 81
-h 11
-font "arial-medium-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Kinematics active"
-}
-autoSize
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 370
-y 155
-w 12
-h 192
-controlPv "$(pmac):CTRLSTAT:status3"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endObjectProperties
-
-endGroup
-
-endObjectProperties
-
-endGroup
-
-endObjectProperties
-
-endGroup
-
-endObjectProperties
-
-endGroup
-
-visPv "$(pmac):PMACTYPE"
-visMin "1"
-visMax "100"
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 695
-w 250
-h 85
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 495
-w 305
-h 55
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 45
-w 255
-h 85
+h 75
 lineColor index 14
 fill
 fillColor index 5
@@ -2620,26 +241,18 @@ endGroup
 
 endObjectProperties
 
-# (Static Text)
-object activeXTextClass
+# (Group)
+object activeGroupClass
 beginObjectProperties
 major 4
-minor 1
-release 1
-x 5
-y 35
-w 71
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  PMAC Info  "
-}
-autoSize
-border
-endObjectProperties
+minor 0
+release 0
+x 265
+y 790
+w 305
+h 135
+
+beginGroup
 
 # (Rectangle)
 object activeRectangleClass
@@ -2647,10 +260,10 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 270
-y 45
-w 300
-h 85
+x 265
+y 800
+w 305
+h 125
 lineColor index 14
 fill
 fillColor index 5
@@ -2663,18 +276,457 @@ major 4
 minor 1
 release 1
 x 270
-y 35
-w 78
+y 805
+w 135
+h 20
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Response (ECHO)"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 265
+y 790
+w 97
 h 13
 font "arial-medium-r-12.0"
 fontAlign "center"
 fgColor index 14
 bgColor index 8
 value {
-  "  Error Status  "
+  "  PMAC Settings  "
 }
 autoSize
 border
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 415
+y 805
+w 145
+h 20
+controlPv "$(pmac):READ_ECHO"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):PMACTYPE"
+visMin "0"
+visMax "1"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 790
+w 305
+h 135
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 800
+w 305
+h 125
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 6
+release 0
+x 445
+y 880
+w 120
+h 12
+controlPv "$(pmac):VME_ADDR_MODE"
+font "arial-medium-r-10.0"
+fgColor index 16
+bgColor index 10
+limitsFromDb
+nullColor index 0
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 880
+w 126
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "VME Address Modifier (I90)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 895
+w 117
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "VME Interrupt Level (I95)"
+}
+autoSize
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 6
+release 0
+x 445
+y 895
+w 120
+h 12
+controlPv "$(pmac):VME_INTLVL"
+font "arial-medium-r-10.0"
+fgColor index 16
+bgColor index 10
+limitsFromDb
+nullColor index 0
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 805
+w 118
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "PLC Program Control (I5)"
+}
+autoSize
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 6
+release 0
+x 445
+y 805
+w 120
+h 12
+controlPv "$(pmac):PLC_CONTROL"
+font "arial-medium-r-10.0"
+fgColor index 16
+bgColor index 10
+autoHeight
+limitsFromDb
+nullColor index 0
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 6
+release 0
+x 445
+y 835
+w 120
+h 12
+controlPv "$(pmac):ERRREPMODE"
+font "arial-medium-r-10.0"
+fgColor index 16
+bgColor index 10
+limitsFromDb
+nullColor index 0
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 6
+release 0
+x 445
+y 820
+w 120
+h 12
+controlPv "$(pmac):IO_HANDSHAKE"
+font "arial-medium-r-10.0"
+fgColor index 16
+bgColor index 10
+limitsFromDb
+nullColor index 0
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 820
+w 123
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "I/O Handshake Control (I3)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 835
+w 119
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Error Reporting Mode (I6)"
+}
+autoSize
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 6
+release 0
+x 445
+y 850
+w 120
+h 12
+controlPv "$(pmac):DPRAM_COMMS_INT"
+font "arial-medium-r-10.0"
+fgColor index 16
+bgColor index 10
+limitsFromDb
+nullColor index 0
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 6
+release 0
+x 445
+y 865
+w 120
+h 12
+controlPv "$(pmac):DPRAM_COMMS"
+font "arial-medium-r-10.0"
+fgColor index 16
+bgColor index 10
+limitsFromDb
+nullColor index 0
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 865
+w 129
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "DPRAM ASCII Comms (I58)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 850
+w 173
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "DPRAM ASCII Comms Interrupt (I56)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 265
+y 790
+w 97
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  PMAC Settings  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 6
+release 0
+x 445
+y 910
+w 120
+h 12
+controlPv "$(pmac):VME_DPRAMBASE"
+format "hex"
+font "arial-medium-r-10.0"
+fgColor index 16
+bgColor index 10
+limitsFromDb
+nullColor index 0
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 910
+w 153
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "VME DPRAM Base Address (I97)"
+}
+autoSize
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):PMACTYPE"
+visMin "1"
+visMax "100"
 endObjectProperties
 
 # (Exit Button)
@@ -2684,7 +736,7 @@ major 4
 minor 1
 release 0
 x 460
-y 855
+y 935
 w 110
 h 25
 fgColor index 46
@@ -2696,439 +748,6 @@ font "arial-medium-r-18.0"
 3d
 endObjectProperties
 
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 50
-w 85
-h 30
-font "arial-bold-r-14.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "PMAC Type:"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 75
-w 85
-h 30
-font "arial-bold-r-14.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "CPU Load:"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 265
-y 485
-w 281
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  Motion program activity on Co-ordinate system #  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 275
-y 520
-w 285
-h 20
-controlPv "$(pmac):PROGBITS"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endian "little"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 275
-y 80
-w 140
-h 20
-font "arial-bold-r-14.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "MACRO ring errors:"
-}
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 100
-y 55
-w 155
-h 20
-controlPv "$(pmac):PMACTYPE"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 100
-y 80
-w 155
-h 20
-controlPv "$(pmac):CPULOAD"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 420
-y 80
-w 145
-h 20
-controlPv "$(pmac):MACROERRS"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 375
-w 305
-h 100
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 265
-y 365
-w 96
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  PLCs disabled  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 275
-y 400
-w 285
-h 20
-controlPv "$(pmac):PLCDISBITS00"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endian "little"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 280
-y 385
-w 276
-h 10
-font "courier-bold-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15"
-}
-autoSize
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 275
-y 445
-w 285
-h 20
-controlPv "$(pmac):PLCDISBITS01"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endian "little"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 275
-y 430
-w 282
-h 10
-font "courier-bold-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 280
-y 505
-w 276
-h 10
-font "courier-bold-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16"
-}
-autoSize
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 570
-w 305
-h 55
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 265
-y 560
-w 144
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  General Purpose Inputs  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 275
-y 595
-w 285
-h 20
-controlPv "$(pmac):GPIO_INP_BITS"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endian "little"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 280
-y 580
-w 276
-h 10
-font "courier-bold-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16"
-}
-autoSize
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 645
-w 305
-h 55
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 265
-y 635
-w 154
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  General Purpose Outputs  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 275
-y 670
-w 285
-h 20
-controlPv "$(pmac):GPIO_OP_BITS"
-lineColor index 14
-onColor index 15
-offColor index 19
-lineWidth 2
-endian "little"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 280
-y 655
-w 276
-h 10
-font "courier-bold-r-10.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16"
-}
-autoSize
-endObjectProperties
-
 # (Rectangle)
 object activeRectangleClass
 beginObjectProperties
@@ -3136,198 +755,7 @@ major 4
 minor 0
 release 0
 x 5
-y 375
-w 250
-h 85
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 365
-w 120
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  Additional Screens  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Related Display)
-object relatedDisplayClass
-beginObjectProperties
-major 4
-minor 4
-release 0
-x 140
-y 385
-w 105
-h 25
-fgColor index 43
-bgColor index 3
-topShadowColor index 1
-botShadowColor index 11
-font "arial-bold-r-14.0"
-buttonLabel "Trajectory"
-numPvs 4
-numDsps 1
-displayFileName {
-  0 "pmacTrajectory"
-}
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 420
-y 55
-w 15
-h 15
-controlPv "$(pmac):GLOBAL_PROBLEM_RBV"
-lineColor index 14
-onColor index 20
-offColor index 24
-lineWidth 2
-numBits 1
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 275
-y 55
-w 140
-h 20
-font "arial-bold-r-14.0"
-fgColor index 14
-bgColor index 0
-useDisplayBg
-value {
-  "Controller Problem:"
-}
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 100
-y 105
-w 155
-h 20
-controlPv "$(pmac):SERVO_FREQ"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 100
-w 85
-h 30
-font "arial-bold-r-14.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "Servo Freq:"
-}
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 620
-w 250
-h 55
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Choice Button)
-object activeChoiceButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 20
-y 640
-w 220
-h 25
-fgColor index 25
-bgColor index 5
-selectColor index 5
-inconsistentColor index 5
-topShadowColor index 1
-botShadowColor index 11
-controlPv "$(pmac):DeferMoves"
-indicatorPv "$(pmac):DeferMoves"
-font "helvetica-bold-r-14.0"
-orientation "horizontal"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 615
-w 95
-h 13
-font "arial-medium-r-12.0"
-fgColor index 14
-bgColor index 8
-value {
-  "  Deferred move  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 475
+y 555
 w 250
 h 130
 lineColor index 14
@@ -3342,7 +770,7 @@ major 4
 minor 1
 release 1
 x 5
-y 470
+y 550
 w 63
 h 13
 font "arial-medium-r-12.0"
@@ -3362,7 +790,7 @@ major 10
 minor 0
 release 0
 x 180
-y 570
+y 650
 w 70
 h 20
 controlPv "$(pmac):FEEDRATE_LIMIT"
@@ -3383,7 +811,7 @@ major 4
 minor 1
 release 1
 x 10
-y 570
+y 650
 w 155
 h 20
 font "arial-medium-r-12.0"
@@ -3402,7 +830,7 @@ major 4
 minor 1
 release 1
 x 10
-y 520
+y 600
 w 160
 h 20
 font "arial-medium-r-12.0"
@@ -3421,7 +849,7 @@ major 10
 minor 0
 release 0
 x 180
-y 520
+y 600
 w 70
 h 20
 controlPv "$(pmac):FEEDRATE"
@@ -3435,6 +863,2362 @@ font "arial-bold-r-14.0"
 fontAlign "center"
 endObjectProperties
 
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 180
+y 625
+w 70
+h 20
+controlPv "$(pmac):FEEDRATE_RBV"
+displayMode "decimal"
+precision 2
+fgColor index 15
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 625
+w 160
+h 20
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 10
+useDisplayBg
+value {
+  "Current lowest feedrate"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 575
+w 160
+h 20
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 10
+useDisplayBg
+value {
+  "Feedrate problem:"
+}
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 235
+y 575
+w 15
+h 15
+controlPv "$(pmac):FEEDRATE_PROBLEM_RBV"
+lineColor index 14
+onColor index 20
+offColor index 24
+lineWidth 2
+numBits 1
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 120
+w 78
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  PMAC CPU  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 175
+w 85
+h 30
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "CPU Load:"
+}
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 340
+y 165
+w 100
+h 35
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 340
+y 165
+w 42
+h 13
+font "courier-bold-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Core 3"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 340
+y 180
+w 75
+h 20
+controlPv "$(pmac):CPULOAD_3"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):CPUNUMCORES"
+visMin "4"
+visMax "5"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 260
+y 165
+w 100
+h 35
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 260
+y 165
+w 42
+h 13
+font "courier-bold-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Core 2"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 260
+y 180
+w 75
+h 20
+controlPv "$(pmac):CPULOAD_2"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):CPUNUMCORES"
+visMin "3"
+visMax "5"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 180
+y 165
+w 100
+h 35
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 180
+y 165
+w 42
+h 13
+font "courier-bold-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Core 1"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 180
+y 180
+w 75
+h 20
+controlPv "$(pmac):CPULOAD_1"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):CPUNUMCORES"
+visMin "2"
+visMax "5"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 100
+y 165
+w 100
+h 35
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 100
+y 165
+w 42
+h 13
+font "courier-bold-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Core 0"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 100
+y 180
+w 75
+h 20
+controlPv "$(pmac):CPULOAD_0"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 10
+y 135
+w 245
+h 30
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 135
+w 85
+h 30
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "CPU Cores:"
+}
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 100
+y 140
+w 155
+h 20
+controlPv "$(pmac):CPUNUMCORES"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 210
+w 565
+h 220
+
+beginGroup
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 220
+w 565
+h 210
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 220
+w 565
+h 210
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 15
+y 230
+w 130
+h 192
+
+beginGroup
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 15
+y 230
+w 12
+h 192
+controlPv "$(pmac):CTRLSTAT:status1"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 411
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 399
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 387
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 375
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 363
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 351
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 339
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 327
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 315
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 303
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 291
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 279
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 267
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 255
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 243
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 30
+y 231
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 370
+y 230
+w 189
+h 192
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 411
+w 138
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Software watchdog fault bit 2"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 399
+w 138
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Software watchdog fault bit 1"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 387
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Power on/reset load fault"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 375
+w 80
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Project load error"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 363
+w 142
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Saved configuration load error"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 351
+w 174
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Hardware change detected since save"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 339
+w 140
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "System file configuration error"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 327
+w 135
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Factory default configuration"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 315
+w 107
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "No system clocks found"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 303
+w 85
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Abort all condition"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 291
+w 105
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Insufficient user buffer"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 279
+w 116
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Insufficient flash memory"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 267
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 255
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 243
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 231
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 370
+y 230
+w 12
+h 192
+controlPv "$(pmac):CTRLSTAT:status2"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):PMACTYPE"
+visMin "0"
+visMax "1"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 210
+w 565
+h 220
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 220
+w 565
+h 210
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 210
+w 87
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  PMAC Status  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 15
+y 230
+w 507
+h 193
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 410
+w 125
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Illegal L variable definition"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 398
+w 136
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Real-Time Interrupt Warning"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 386
+w 50
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Flash error"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 374
+w 64
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "DPRAM error"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 362
+w 111
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "PROM checksum active"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 350
+w 133
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Any memory checksum error"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 338
+w 129
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Leadscrew compensation on"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 326
+w 74
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Watchdog timer"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 314
+w 67
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Servo Request"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 302
+w 127
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Data gather start on trigger"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 290
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 278
+w 134
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Data Gathering Function On"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 266
+w 53
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Servo Error"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 254
+w 73
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "CPU Type Bit 1"
+}
+autoSize
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 15
+y 230
+w 12
+h 192
+controlPv "$(pmac):CTRLSTAT:status1"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 242
+w 127
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Real-time interrupt re-entry"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 31
+y 230
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 185
+y 230
+w 337
+h 193
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 410
+w 67
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "UMAC System"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 398
+w 76
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "PLC buffer open"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 386
+w 113
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "ASCII rotary buffer open"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 374
+w 87
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Motion buffer open"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 362
+w 122
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Binary rotary buffers open"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 350
+w 72
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "CPU Type Bit 0"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 338
+w 54
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Turbo VME"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 326
+w 69
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Turbo Ultralite"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 314
+w 92
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "This card addressed"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 302
+w 90
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "All cards addressed"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 290
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 278
+w 93
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Phase clock missing"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 266
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "MACRO ring check error"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 242
+w 119
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "TWS variable parity error"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 230
+w 89
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Configuration error"
+}
+autoSize
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 185
+y 230
+w 12
+h 192
+controlPv "$(pmac):CTRLSTAT:status2"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 201
+y 254
+w 162
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "MACRO aux. communication error"
+}
+autoSize
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 370
+y 230
+w 152
+h 193
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 411
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 398
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 386
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 374
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 362
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 350
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 338
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 326
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 314
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 302
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 290
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 278
+w 115
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "(Reserved for future use)"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 266
+w 75
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Fixed buffer full"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 254
+w 137
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Ring master-to-master comms"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 242
+w 81
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Kinematics active"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 385
+y 230
+w 81
+h 11
+font "arial-medium-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Kinematics active"
+}
+autoSize
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 370
+y 230
+w 12
+h 192
+controlPv "$(pmac):CTRLSTAT:status3"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+endGroup
+
+visPv "$(pmac):PMACTYPE"
+visMin "1"
+visMax "100"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 210
+w 125
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+visPv "$(pmac):PMACTYPE"
+visMin "0"
+visMax "1"
+value {
+  "  Power Pmac Status  "
+}
+autoSize
+border
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 445
+w 250
+h 95
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 455
+w 250
+h 85
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 445
+w 120
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  Additional Screens  "
+}
+autoSize
+border
+endObjectProperties
+
 # (Related Display)
 object relatedDisplayClass
 beginObjectProperties
@@ -3442,7 +3226,30 @@ major 4
 minor 4
 release 0
 x 140
-y 420
+y 465
+w 105
+h 25
+fgColor index 43
+bgColor index 3
+topShadowColor index 1
+botShadowColor index 11
+font "arial-bold-r-14.0"
+buttonLabel "Trajectory"
+numPvs 4
+numDsps 1
+displayFileName {
+  0 "pmacTrajectory"
+}
+endObjectProperties
+
+# (Related Display)
+object relatedDisplayClass
+beginObjectProperties
+major 4
+minor 4
+release 0
+x 140
+y 500
 w 105
 h 25
 fgColor index 43
@@ -3465,7 +3272,7 @@ major 4
 minor 4
 release 0
 x 20
-y 385
+y 465
 w 105
 h 25
 fgColor index 43
@@ -3481,212 +3288,6 @@ displayFileName {
 }
 endObjectProperties
 
-# (Message Button)
-object activeMessageButtonClass
-beginObjectProperties
-major 4
-minor 1
-release 0
-x 20
-y 710
-w 220
-h 25
-fgColor index 21
-onColor index 4
-offColor index 3
-topShadowColor index 1
-botShadowColor index 11
-controlPv "$(pmac):StopAll"
-pressValue "1"
-onLabel "STOP"
-offLabel "STOP"
-3d
-useEnumNumeric
-font "arial-bold-r-14.0"
-visMin "0"
-visMax "1"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 685
-w 66
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  All Motors  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Message Button)
-object activeMessageButtonClass
-beginObjectProperties
-major 4
-minor 1
-release 0
-x 20
-y 745
-w 220
-h 25
-fgColor index 21
-onColor index 4
-offColor index 3
-topShadowColor index 1
-botShadowColor index 11
-controlPv "$(pmac):KillAll"
-pressValue "1"
-onLabel "KILL"
-offLabel "KILL"
-3d
-useEnumNumeric
-font "arial-bold-r-14.0"
-visMin "0"
-visMax "1"
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 180
-y 545
-w 70
-h 20
-controlPv "$(pmac):FEEDRATE_RBV"
-displayMode "decimal"
-precision 2
-fgColor index 15
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-14.0"
-fontAlign "center"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 545
-w 160
-h 20
-font "arial-medium-r-12.0"
-fgColor index 14
-bgColor index 10
-useDisplayBg
-value {
-  "Current lowest feedrate"
-}
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 800
-w 250
-h 45
-lineColor index 14
-fill
-fillColor index 5
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 790
-w 197
-h 13
-font "arial-medium-r-12.0"
-fontAlign "center"
-fgColor index 14
-bgColor index 8
-value {
-  "  Select Coordinate System Group  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Menu Button)
-object activeMenuButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 20
-y 810
-w 220
-h 25
-fgColor index 14
-bgColor index 3
-inconsistentColor index 14
-topShadowColor index 1
-botShadowColor index 11
-controlPv "$(pmac):COORDINATE_SYS_GROUP"
-indicatorPv "$(pmac):COORDINATE_SYS_GROUP"
-font "arial-bold-r-14.0"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 495
-w 160
-h 20
-font "arial-medium-r-12.0"
-fgColor index 14
-bgColor index 10
-useDisplayBg
-value {
-  "Feedrate problem:"
-}
-endObjectProperties
-
-# (Byte)
-object ByteClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 235
-y 495
-w 15
-h 15
-controlPv "$(pmac):FEEDRATE_PROBLEM_RBV"
-lineColor index 14
-onColor index 20
-offColor index 24
-lineWidth 2
-numBits 1
-endObjectProperties
-
 # (Extended Related Display)
 object ExtendedRelatedDisplayClass
 beginObjectProperties
@@ -3694,7 +3295,7 @@ major 4
 minor 0
 release 0
 x 20
-y 420
+y 500
 w 105
 h 25
 fgColor index 43
@@ -3731,6 +3332,525 @@ symbols {
 }
 endObjectProperties
 
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 445
+w 305
+h 110
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 455
+w 305
+h 100
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 465
+w 285
+h 80
+
+beginGroup
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 465
+w 285
+h 80
+
+beginGroup
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 465
+w 285
+h 80
+
+beginGroup
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 510
+w 285
+h 35
+
+beginGroup
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 525
+w 285
+h 20
+controlPv "$(pmac):PLCDISBITS01"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endian "little"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 275
+y 510
+w 282
+h 10
+font "courier-bold-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31"
+}
+autoSize
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 465
+w 285
+h 35
+
+beginGroup
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 480
+w 285
+h 20
+controlPv "$(pmac):PLCDISBITS00"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endian "little"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 280
+y 465
+w 276
+h 10
+font "courier-bold-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15"
+}
+autoSize
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 265
+y 445
+w 96
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  PLCs disabled  "
+}
+autoSize
+border
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 565
+w 305
+h 65
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 575
+w 305
+h 55
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 265
+y 565
+w 281
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  Motion program activity on Co-ordinate system #  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 600
+w 285
+h 20
+controlPv "$(pmac):PROGBITS"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endian "little"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 280
+y 585
+w 276
+h 10
+font "courier-bold-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16"
+}
+autoSize
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 640
+w 305
+h 65
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 650
+w 305
+h 55
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 265
+y 640
+w 144
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  General Purpose Inputs  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 675
+w 285
+h 20
+controlPv "$(pmac):GPIO_INP_BITS"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endian "little"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 280
+y 660
+w 276
+h 10
+font "courier-bold-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16"
+}
+autoSize
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 715
+w 305
+h 65
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 725
+w 305
+h 55
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 265
+y 715
+w 154
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  General Purpose Outputs  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 750
+w 285
+h 20
+controlPv "$(pmac):GPIO_OP_BITS"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+endian "little"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 280
+y 735
+w 276
+h 10
+font "courier-bold-r-10.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16"
+}
+autoSize
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 870
+w 250
+h 55
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 880
+w 250
+h 45
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
 # (Static Text)
 object activeXTextClass
 beginObjectProperties
@@ -3738,20 +3858,494 @@ major 4
 minor 1
 release 1
 x 5
-y 135
-w 125
+y 870
+w 197
 h 13
 font "arial-medium-r-12.0"
 fontAlign "center"
 fgColor index 14
 bgColor index 8
-visPv "$(pmac):PMACTYPE"
-visMin "0"
-visMax "1"
 value {
-  "  Power Pmac Status  "
+  "  Select Coordinate System Group  "
 }
 autoSize
 border
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 20
+y 890
+w 220
+h 25
+fgColor index 14
+bgColor index 3
+inconsistentColor index 14
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(pmac):COORDINATE_SYS_GROUP"
+indicatorPv "$(pmac):COORDINATE_SYS_GROUP"
+font "arial-bold-r-14.0"
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 765
+w 250
+h 95
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 775
+w 250
+h 85
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 20
+y 790
+w 220
+h 25
+fgColor index 21
+onColor index 4
+offColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(pmac):StopAll"
+pressValue "1"
+onLabel "STOP"
+offLabel "STOP"
+3d
+useEnumNumeric
+font "arial-bold-r-14.0"
+visMin "0"
+visMax "1"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 765
+w 66
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  All Motors  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 20
+y 825
+w 220
+h 25
+fgColor index 21
+onColor index 4
+offColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(pmac):KillAll"
+pressValue "1"
+onLabel "KILL"
+offLabel "KILL"
+3d
+useEnumNumeric
+font "arial-bold-r-14.0"
+visMin "0"
+visMax "1"
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 695
+w 250
+h 60
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 700
+w 250
+h 55
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Choice Button)
+object activeChoiceButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 20
+y 720
+w 220
+h 25
+fgColor index 25
+bgColor index 5
+selectColor index 5
+inconsistentColor index 5
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(pmac):DeferMoves"
+indicatorPv "$(pmac):DeferMoves"
+font "helvetica-bold-r-14.0"
+orientation "horizontal"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 695
+w 95
+h 13
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 8
+value {
+  "  Deferred move  "
+}
+autoSize
+border
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 35
+w 255
+h 75
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 45
+w 255
+h 65
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 50
+w 85
+h 30
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "PMAC Type:"
+}
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 100
+y 55
+w 155
+h 20
+controlPv "$(pmac):PMACTYPE"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 10
+y 75
+w 245
+h 30
+
+beginGroup
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 100
+y 80
+w 155
+h 20
+controlPv "$(pmac):SERVO_FREQ"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 75
+w 85
+h 30
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Servo Freq:"
+}
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 35
+w 71
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  PMAC Info  "
+}
+autoSize
+border
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 270
+y 35
+w 300
+h 75
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 270
+y 45
+w 300
+h 65
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 270
+y 35
+w 78
+h 13
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  Error Status  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 275
+y 80
+w 140
+h 20
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "MACRO ring errors:"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 275
+y 55
+w 140
+h 20
+font "arial-bold-r-14.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Controller Problem:"
+}
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 420
+y 55
+w 15
+h 15
+controlPv "$(pmac):GLOBAL_PROBLEM_RBV"
+lineColor index 14
+onColor index 20
+offColor index 24
+lineWidth 2
+numBits 1
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 420
+y 80
+w 145
+h 20
+controlPv "$(pmac):MACROERRS"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-14.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
 endObjectProperties
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -4170,6 +4170,9 @@ asynStatus pmacController::getCpuNumCores() {
   }
 
   if(status == asynSuccess) {
+    printf("%s:%s: CPU type %s\n", driverName, functionName, cpu_.c_str());
+    printf("%s:%s: Number of cores %d\n", driverName, functionName, cpuNumCores_);
+
     if(cpuNumCores_ < 1 || cpuNumCores_ > PPMAC_CPU_MAXCORES) {
       debugf(DEBUG_ERROR, functionName,
             "Detected number of CPU Cores (%d) is out of supported range (1 to %d)", cpuNumCores_, PPMAC_CPU_MAXCORES);
@@ -4193,9 +4196,6 @@ asynStatus pmacController::getTasksCore() {
 
   // Single-core Power PC
   if (strcmp(cpu_.c_str(), "PowerPC,460EX") == 0) {
-    debug(DEBUG_TRACE, functionName, "CPU type", cpu_.c_str());
-    debug(DEBUG_TRACE, functionName, "Number of cores", cpuNumCores_);
-
     // CPU Core 0 executes all tasks: Phase, Servo, RT and Background
     cpuCoreTasks_[PPMAC_CPU_PHASETASK] = 0;
     cpuCoreTasks_[PPMAC_CPU_SERVOTASK] = 0;
@@ -4204,9 +4204,6 @@ asynStatus pmacController::getTasksCore() {
 
   // Dual-core Power PC
   } else if (strcmp(cpu_.c_str(), "PowerPC,APM86xxx") == 0) {
-    debug(DEBUG_TRACE, functionName, "CPU type", cpu_.c_str());
-    debug(DEBUG_TRACE, functionName, "Number of cores", cpuNumCores_);
-
     // CPU Core 0 executes: Background tasks
     cpuCoreTasks_[PPMAC_CPU_BGTASK] = 0;
     // CPU Core 1 executes: Phase, Servo and RT tasks
@@ -4217,9 +4214,6 @@ asynStatus pmacController::getTasksCore() {
   // Dual-core/ Quad-core ARM
   } else if(strcmp(cpu_.c_str(), "arm,LS1021A") == 0 ||
             strcmp(cpu_.c_str(), "arm,LS1043A") == 0) {
-    debug(DEBUG_TRACE, functionName, "CPU type", cpu_.c_str());
-    debug(DEBUG_TRACE, functionName, "Number of cores", cpuNumCores_);
-
     for (int task_idx = 0; task_idx < PPMAC_CPU_TASKS_NUM; task_idx++) {
       // get task Core command
       int taskCore;

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -4172,7 +4172,7 @@ asynStatus pmacController::getCpuNumCores() {
   if(status == asynSuccess) {
     if(cpuNumCores_ < 1 || cpuNumCores_ > PPMAC_CPU_MAXCORES) {
       debugf(DEBUG_ERROR, functionName,
-            "Detected number of CPU Cores (%d) is out of supported range (1 to 4)", cpuNumCores_);
+            "Detected number of CPU Cores (%d) is out of supported range (1 to %d)", cpuNumCores_, PPMAC_CPU_MAXCORES);
     }
   }
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -4130,10 +4130,6 @@ asynStatus pmacController::readDeviceType() {
       if (cpu_.find("\r") != std::string::npos) {
         cpu_ = cpu_.substr(0, cpu_.find("\r"));
       }
-      // Remove any LF characters
-      if (cpu_.find("\n") != std::string::npos) {
-        cpu_ = cpu_.erase(cpu_.find("\n"),1);
-      }
     } else {
       debug(DEBUG_ERROR, functionName, "Error reading card cpu");
       debug(DEBUG_ERROR, functionName, "    response", reply);

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -1752,7 +1752,7 @@ asynStatus pmacController::fastUpdate(pmacCommandStore *sPtr) {
     double tasksPercent[PPMAC_CPU_TASKS_NUM];
 
     // Final result
-    double cpuLoad_[cpuNumCores_];
+    std::vector<double> cpuLoad_(cpuNumCores_,0.0);
 
     // Calculation of each task
     if (status == asynSuccess) {

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -4176,7 +4176,7 @@ asynStatus pmacController::getCpuNumCores() {
   if(status == asynSuccess) {
     if(cpuNumCores_ < 1 || cpuNumCores_ > PPMAC_CPU_MAXCORES) {
       debugf(DEBUG_ERROR, functionName,
-            "Number of CPU Cores (%d) out of supported range (0-4)", cpuNumCores_);
+            "Detected number of CPU Cores (%d) is out of supported range (1 to 4)", cpuNumCores_);
     }
   }
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -1795,18 +1795,18 @@ asynStatus pmacController::fastUpdate(pmacCommandStore *sPtr) {
       phaseFreq = 1/(phaseDeltaTime/1000000);
       phasePercent = (phaseTaskTimeUs / phaseDeltaTime)*100;
       tasksPercent[PPMAC_CPU_PHASETASK] = phasePercent;
-      debug(DEBUG_TRACE, functionName, "Phase Interrupt Frequency (Hz)", phaseFreq);
-      debug(DEBUG_TRACE, functionName, "Phase Interrupt Time (us)", phaseTaskTimeUs);
-      debug(DEBUG_TRACE, functionName, "Phase Interrupt %", phasePercent);
+      debug(DEBUG_VARIABLE, functionName, "Phase Interrupt Frequency (Hz)", phaseFreq);
+      debug(DEBUG_VARIABLE, functionName, "Phase Interrupt Time (us)", phaseTaskTimeUs);
+      debug(DEBUG_VARIABLE, functionName, "Phase Interrupt %", phasePercent);
 
       // Determine servo percentage
       servoFreq = 1/(servoDeltaTime/1000000);
       servoTaskTimeUs = servoTimeUs - ((double)(int)((servoTimeUs/phaseDeltaTime)+1)) * phaseTaskTimeUs;
       servoPercent = (servoTaskTimeUs / servoDeltaTime)*100;
       tasksPercent[PPMAC_CPU_SERVOTASK] = servoPercent;
-      debug(DEBUG_TRACE, functionName, "Servo Interrupt Frequency (Hz)", servoFreq);
-      debug(DEBUG_TRACE, functionName, "Servo Interrupt Time (us)", servoTaskTimeUs);
-      debug(DEBUG_TRACE, functionName, "Servo Interrupt %", servoPercent);
+      debug(DEBUG_VARIABLE, functionName, "Servo Interrupt Frequency (Hz)", servoFreq);
+      debug(DEBUG_VARIABLE, functionName, "Servo Interrupt Time (us)", servoTaskTimeUs);
+      debug(DEBUG_VARIABLE, functionName, "Servo Interrupt %", servoPercent);
 
       // Determine real time percentage
       rtFreq = 1/(rtiDeltaTime/1000000);
@@ -1814,9 +1814,9 @@ asynStatus pmacController::fastUpdate(pmacCommandStore *sPtr) {
       rtTaskTimeUs = rtTaskTimeUs - ((double)(int)((rtTimeUs/servoDeltaTime)+1)) * servoTaskTimeUs;
       rtPercent = (rtTaskTimeUs / rtiDeltaTime)*100;
       tasksPercent[PPMAC_CPU_RTTASK] = rtPercent;
-      debug(DEBUG_TRACE, functionName, "Real Time Interrupt Frequency (Hz)", rtFreq);
-      debug(DEBUG_TRACE, functionName, "Real Time Interrupt Time (us)", rtTaskTimeUs);
-      debug(DEBUG_TRACE, functionName, "Real Time Interrupt %", rtPercent);
+      debug(DEBUG_VARIABLE, functionName, "Real Time Interrupt Frequency (Hz)", rtFreq);
+      debug(DEBUG_VARIABLE, functionName, "Real Time Interrupt Time (us)", rtTaskTimeUs);
+      debug(DEBUG_VARIABLE, functionName, "Real Time Interrupt %", rtPercent);
 
       // Background tasks percentage
       bgFreq = 1/ (bgDeltaTime/1000000);
@@ -1825,9 +1825,9 @@ asynStatus pmacController::fastUpdate(pmacCommandStore *sPtr) {
       bgTaskTimeUs = bgTaskTimeUs - (double)(int)(bgTimeUs/rtiDeltaTime)*rtTaskTimeUs;
       bgPercent = (bgTaskTimeUs / bgDeltaTime)*100;
       tasksPercent[PPMAC_CPU_BGTASK] = bgPercent;
-      debug(DEBUG_TRACE, functionName, "Background Interrupt Frequency (Hz)", bgFreq);
-      debug(DEBUG_TRACE, functionName, "Background Interrupt Time (us)", bgTaskTimeUs);
-      debug(DEBUG_TRACE, functionName, "Background Interrupt %", bgPercent);
+      debug(DEBUG_VARIABLE, functionName, "Background Interrupt Frequency (Hz)", bgFreq);
+      debug(DEBUG_VARIABLE, functionName, "Background Interrupt Time (us)", bgTaskTimeUs);
+      debug(DEBUG_VARIABLE, functionName, "Background Interrupt %", bgPercent);
 
       for (int task_idx = 0; task_idx < PPMAC_CPU_TASKS_NUM; task_idx++) {
         int core = cpuCoreTasks_[task_idx];
@@ -1839,7 +1839,7 @@ asynStatus pmacController::fastUpdate(pmacCommandStore *sPtr) {
 
       int cpuParams[] = {PMAC_C_CpuUsage0_, PMAC_C_CpuUsage1_, PMAC_C_CpuUsage2_, PMAC_C_CpuUsage3_};
       for (int core = 0; core < cpuNumCores_; core++) {
-        debugf(DEBUG_TRACE, functionName, "Calculated CPU[%d] %.2f%", core, cpuLoad_[core]);
+        debugf(DEBUG_VARIABLE, functionName, "Calculated CPU[%d] %.2f%", core, cpuLoad_[core]);
         setDoubleParam(cpuParams[core], cpuLoad_[core]);
       }
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -4153,7 +4153,9 @@ asynStatus pmacController::getCpuNumCores() {
 
   if (status == asynSuccess) {
     // Single-core
-    if (strcmp(cpu_.c_str(),"PowerPC,460EX") == 0) {
+    if (strcmp(cpu_.c_str(),PMAC_CPU_GEO_240MHZ) == 0 ||
+        strcmp(cpu_.c_str(),PMAC_CPU_CLIPPER) == 0 ||
+        strcmp(cpu_.c_str(),"PowerPC,460EX") == 0) {
       cpuNumCores_ = 1;
     // Dual-core
     } else if (strcmp(cpu_.c_str(),"PowerPC,APM86xxx") == 0 ||

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -201,8 +201,6 @@
 #define PMAC_CPU_I8              "I8"    // RTI period (Servo cycles - 1)
 #define PMAC_CPU_I7002           "I7002" // Servo clock divider (ServoClockFreq = PhaseClockFreq/(ServoClockDiv + 1) )
 
-#define PPMAC_CPU_FREQ           "Sys.CPUFreq"
-#define PPMAC_CPU_TYPE           "Sys.CPUType"
 #define PPMAC_CPU_FPHASE_TIME    "Sys.FltrPhaseTime"
 #define PPMAC_CPU_FSERVO_TIME    "Sys.FltrServoTime"
 #define PPMAC_CPU_FRTI_TIME      "Sys.FltrRtIntTime"
@@ -211,17 +209,13 @@
 #define PPMAC_CPU_SERVOD_TIME    "Sys.ServoDeltaTime"
 #define PPMAC_CPU_RTID_TIME      "Sys.RtIntDeltaTime"
 #define PPMAC_CPU_BGD_TIME       "Sys.BgDeltaTime"
-#define PPMAC_CPU_PHASE_SERV_PER "Sys.PhaseOverServoPeriod"
-#define PPMAC_CPU_SERVO_PERIOD   "Sys.ServoPeriod"
-#define PPMAC_CPU_RTI_PERIOD     "Sys.RtIntPeriod"
-#define PPMAC_CPU_BGSLEEP_TIME   "Sys.BgSleepTime"
 
-#define PPMAC_CPU_MAXCORES      4
-#define PPMAC_CPU_TASKS_NUM     4
-#define PPMAC_CPU_PHASETASK     0
-#define PPMAC_CPU_SERVOTASK     1
-#define PPMAC_CPU_RTTASK        2
-#define PPMAC_CPU_BGTASK        3
+#define PPMAC_CPU_MAXCORES      4 // Maximum number of cores currently supported
+#define PPMAC_CPU_TASKS_NUM     4 // Number of tasks supported by the PowerPMAC core management
+#define PPMAC_CPU_PHASETASK     0 // Highest priority task
+#define PPMAC_CPU_SERVOTASK     1 // ...
+#define PPMAC_CPU_RTTASK        2 // ...
+#define PPMAC_CPU_BGTASK        3 // Lowest priority task
 
 #define PMAC_TRAJ_STATUS         "M4034" // Status of motion program for EPICS - 0: Idle, 1: Running, 2: Finished, 3: Error
 #define PMAC_TRAJ_ABORT          "M4035" // Abort trigger for EPICS
@@ -546,12 +540,6 @@ private:
     int i7002_;
     bool csResetAllDemands;
     int csCount;
-    int Sys_CPUFreq_;
-    // int Sys_CPUType_;
-    int Sys_BgSleepTime_;
-    double Sys_ServoPeriod_;
-    double Sys_RtIntPeriod_;
-    double Sys_PhaseOverServoPeriod_;
 
 
     // Trajectory scan variables

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -53,7 +53,11 @@
 
 #define PMAC_C_FastUpdateTimeString       "PMAC_C_FAST_UPDATE_TIME"
 
-#define PMAC_C_CpuUsageString             "PMAC_C_CPU_USAGE"
+#define PMAC_C_CpuNumCoresString          "PMAC_C_CPU_NUM_CORES"
+#define PMAC_C_CpuUsage0String            "PMAC_C_CPU_USAGE_0"
+#define PMAC_C_CpuUsage1String            "PMAC_C_CPU_USAGE_1"
+#define PMAC_C_CpuUsage2String            "PMAC_C_CPU_USAGE_2"
+#define PMAC_C_CpuUsage3String            "PMAC_C_CPU_USAGE_3"
 #define PMAC_C_AxisCSString               "PMAC_C_AXIS_CS"
 #define PMAC_C_AxisReadonlyString         "PMAC_C_AXIS_READONLY"
 #define PMAC_C_WriteCmdString             "PMAC_C_WRITE_CMD"
@@ -212,6 +216,13 @@
 #define PPMAC_CPU_RTI_PERIOD     "Sys.RtIntPeriod"
 #define PPMAC_CPU_BGSLEEP_TIME   "Sys.BgSleepTime"
 
+#define PPMAC_CPU_MAXCORES      4
+#define PPMAC_CPU_TASKS_NUM     4
+#define PPMAC_CPU_PHASETASK     0
+#define PPMAC_CPU_SERVOTASK     1
+#define PPMAC_CPU_RTTASK        2
+#define PPMAC_CPU_BGTASK        3
+
 #define PMAC_TRAJ_STATUS         "M4034" // Status of motion program for EPICS - 0: Idle, 1: Running, 2: Finished, 3: Error
 #define PMAC_TRAJ_ABORT          "M4035" // Abort trigger for EPICS
 #define PMAC_TRAJ_AXES           "M4036" // An int between 1 and 511 specifying which axes to use
@@ -337,6 +348,12 @@ public:
     // Read out the device type (cid)
     asynStatus readDeviceType();
 
+    // Set number of CPU cores based on CPU type
+    asynStatus getCpuNumCores();
+
+    // Get CPU core for each task
+    asynStatus getTasksCore();
+
     // List PLC program
     asynStatus listPLCProgram(int plcNo, char *buffer, size_t size);
     asynStatus executeManualGroup();
@@ -375,7 +392,11 @@ protected:
     int PMAC_C_DebugCmd_;
     int PMAC_C_DisablePolling_;
     int PMAC_C_FastUpdateTime_;
-    int PMAC_C_CpuUsage_;
+    int PMAC_C_CpuNumCores_;
+    int PMAC_C_CpuUsage0_;
+    int PMAC_C_CpuUsage1_;
+    int PMAC_C_CpuUsage2_;
+    int PMAC_C_CpuUsage3_;
     int PMAC_C_AxisCS_;
     int PMAC_C_AxisReadonly_;
     int PMAC_C_WriteCmd_;
@@ -497,6 +518,8 @@ private:
     int initialised_;
     int cid_;
     std::string cpu_;
+    int cpuNumCores_;
+    int cpuCoreTasks_[PPMAC_CPU_TASKS_NUM];
     int parameterIndex_;
     pmacMessageBroker *pBroker_;
     pmacTrajectory *pTrajectory_;
@@ -524,7 +547,7 @@ private:
     bool csResetAllDemands;
     int csCount;
     int Sys_CPUFreq_;
-    int Sys_CPUType_;
+    // int Sys_CPUType_;
     int Sys_BgSleepTime_;
     double Sys_ServoPeriod_;
     double Sys_RtIntPeriod_;


### PR DESCRIPTION
Improve CPU load calculation for Power PMAC, being possible to read the usage for up to 4 cores.
For ARM architecture, supports custom core management reading the core that executes each task (phase, servo, RT and background). 