### PR TITLE
Fix kinematic update

### DIFF
--- a/pmacApp/src/pmacCSAxis.cpp
+++ b/pmacApp/src/pmacCSAxis.cpp
@@ -391,11 +391,12 @@ asynStatus pmacCSAxis::getAxisStatus(pmacCommandStore *sPtr) {
     direction = 0;
   }
   setIntegerParam(pC_->motorStatusDirection_, direction);
+
+  moving_ = !cStatus.done_ || deferredMove_ || position != previous_position_;
+
   // Store position to calculate direction for next poll.
   previous_position_ = position;
   previous_direction_ = direction;
-
-  moving_ = !cStatus.done_ || deferredMove_;
 
   setIntegerParam(pC_->motorStatusDone_, !moving_);
   setIntegerParam(pC_->motorStatusMoving_, moving_);


### PR DESCRIPTION
When the .OFF of the real axis was updated, the .VAL of the kinematics did not update. This problem meant that the GUI interface did not update the values ​​correctly, causing an error during the operation of the beamline by researchers.

This change does not impact the current functioning of the getAxisStatus() function and solves the problem of the offset of the real axes with the kinematics. When the offset value is changed, the "position" variable is changed in the first callback and returns to its state in the second callback, causing the motorStatusDone_ parameter to be updated.

Thanks!