### PR TITLE
Fix kinematic update

### DIFF
--- a/pmacApp/src/pmacCSAxis.cpp
+++ b/pmacApp/src/pmacCSAxis.cpp
@@ -395,7 +395,7 @@ asynStatus pmacCSAxis::getAxisStatus(pmacCommandStore *sPtr) {
   previous_position_ = position;
   previous_direction_ = direction;
 
-  moving_ = !cStatus.done_ || deferredMove_;
+  moving_ = !cStatus.done_ || deferredMove_ || updateMove_;
 
   setIntegerParam(pC_->motorStatusDone_, !moving_);
   setIntegerParam(pC_->motorStatusMoving_, moving_);
@@ -405,6 +405,8 @@ asynStatus pmacCSAxis::getAxisStatus(pmacCommandStore *sPtr) {
   setIntegerParam(pC_->motorStatusLowLimit_, cStatus.lowLimit_);
   setIntegerParam(pC_->motorStatusFollowingError_, cStatus.followingError_);
   setIntegerParam(pC_->motorStatusProblem_, cStatus.problem_);
+
+  updateMove_ = 0;
 
   axisProblemFlag = 0;
   if (cStatus.problem_) {

--- a/pmacApp/src/pmacCSAxis.h
+++ b/pmacApp/src/pmacCSAxis.h
@@ -55,6 +55,7 @@ private:
     asynStatus getAxisStatus(pmacCommandStore *sPtr);
 
     int deferredMove_;
+    int updateMove_;
     char deferredCommand_[128];
     int scale_;
     double kinematic_resolution_;

--- a/pmacApp/src/pmacCSController.cpp
+++ b/pmacApp/src/pmacCSController.cpp
@@ -404,6 +404,23 @@ asynStatus pmacCSController::processDeferredMoves(void) {
   return status;
 }
 
+asynStatus pmacCSController::updateAxis() {
+  asynStatus status = asynSuccess;
+  pmacCSAxis *pAxis = NULL;
+  static const char *functionName = "updateAxis";
+
+  //Turn on the deferred motion flag for the involved axes.
+  for (int axis = 0; axis < numAxes_; axis++) {
+    pAxis = getAxis(axis);
+    if (pAxis != NULL) {
+      if (pAxis->updateMove_ == 0) {
+        pAxis->updateMove_ = 1;
+      }
+    }
+  }
+  return status;
+}
+
 void pmacCSController::setDebugLevel(int level, int axis) {
   // Check if an axis or controller wide debug is to be set
   if (axis == 0) {

--- a/pmacApp/src/pmacCSController.h
+++ b/pmacApp/src/pmacCSController.h
@@ -97,6 +97,8 @@ public:
     asynStatus storeKinematics();
     asynStatus listKinematic(int csNo, const std::string &type, char *buffer, size_t size);
 
+    asynStatus updateAxis();
+
 protected:
     pmacCSAxis **pAxes_; // Array of pointers to axis objects
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -2157,15 +2157,24 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     }
 
 
-  } else if (function == PMAC_C_MotorRes_){
+  } 
+  else if (function == PMAC_C_MotorRes_){
     pAxis->setResolution(value);
     // Direct resolution parameter will always match the raw motor
     setDoubleParam(pAxis->axisNo_, PMAC_C_DirectRes_, value);
-  } else if (function == PMAC_C_MotorOffset_){
+  } 
+  else if (function == PMAC_C_MotorOffset_){
     pAxis->setOffset(value);
     // Direct offset parameter will always match the raw motor
     setDoubleParam(pAxis->axisNo_, PMAC_C_DirectOffset_, value);
-  } else if (function == PMAC_C_DirectMove_){
+
+    int csNum = this->getAxis(pAxis->axisNo_)->getAxisCSNo();
+    if (csNum > 0) {
+        csResetAllDemands = true;
+        pCSControllers_[csNum]->updateAxis();
+    }
+  }
+  else if (function == PMAC_C_DirectMove_){
     double baseVelocity = 0.0;
     double velocity = 0.0;
     double acceleration = 0.0;
@@ -2176,7 +2185,8 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     pAxis->setIntegerParam(motorStatusDone_, 0);
     pAxis->callParamCallbacks();
     wakeupPoller();
-  } else if (function == motorLowLimit_) {
+  } 
+  else if (function == motorLowLimit_) {
     // Limits in counts
     int lowLimitCounts = int(std::floor(value/pAxis->scale_ + 0.5));
     int highLimitCounts = int(std::floor(pAxis->highLimit_/pAxis->scale_ + 0.5));


### PR DESCRIPTION
When the .OFF of the real axis was updated, the .VAL of the kinematics did not update. This problem meant that the GUI interface did not update the values ​​correctly, causing an error during the operation of the beamline by researchers.

This change does not impact the current functioning of the getAxisStatus() function and solves the problem of displacement of real axes with kinematics. When the offset value is changed, the position value is changed in the first callback and returns to its state in the second callback, causing the motorStatusDone_ parameter to be updated. Is there another way to fix this problem?

Thanks!