### PR TITLE
Abstract Global status bits

### DIFF
--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -97,38 +97,6 @@ const epicsUInt32 pmacController::PMAC_STATUS2_FORE_IN_POS = (0x1 << 13);
 const epicsUInt32 pmacController::PMAC_STATUS2_NA14 = (0x1 << 14);
 const epicsUInt32 pmacController::PMAC_STATUS2_ASSIGNED_CS = (0x1 << 15);
 
-/*Global status ???*/
-const epicsUInt32 pmacController::PMAC_GSTATUS_CARD_ADDR = (0x1 << 0);
-const epicsUInt32 pmacController::PMAC_GSTATUS_ALL_CARD_ADDR = (0x1 << 1);
-const epicsUInt32 pmacController::PMAC_GSTATUS_RESERVED = (0x1 << 2);
-const epicsUInt32 pmacController::PMAC_GSTATUS_PHASE_CLK_MISS = (0x1 << 3);
-const epicsUInt32 pmacController::PMAC_GSTATUS_MACRO_RING_ERRORCHECK = (0x1 << 4);
-const epicsUInt32 pmacController::PMAC_GSTATUS_MACRO_RING_COMMS = (0x1 << 5);
-const epicsUInt32 pmacController::PMAC_GSTATUS_TWS_PARITY_ERROR = (0x1 << 6);
-const epicsUInt32 pmacController::PMAC_GSTATUS_CONFIG_ERROR = (0x1 << 7);
-const epicsUInt32 pmacController::PMAC_GSTATUS_ILLEGAL_LVAR = (0x1 << 8);
-const epicsUInt32 pmacController::PMAC_GSTATUS_REALTIME_INTR = (0x1 << 9);
-const epicsUInt32 pmacController::PMAC_GSTATUS_FLASH_ERROR = (0x1 << 10);
-const epicsUInt32 pmacController::PMAC_GSTATUS_DPRAM_ERROR = (0x1 << 11);
-const epicsUInt32 pmacController::PMAC_GSTATUS_CKSUM_ACTIVE = (0x1 << 12);
-const epicsUInt32 pmacController::PMAC_GSTATUS_CKSUM_ERROR = (0x1 << 13);
-const epicsUInt32 pmacController::PMAC_GSTATUS_LEADSCREW_COMP = (0x1 << 14);
-const epicsUInt32 pmacController::PMAC_GSTATUS_WATCHDOG = (0x1 << 15);
-const epicsUInt32 pmacController::PMAC_GSTATUS_SERVO_REQ = (0x1 << 16);
-const epicsUInt32 pmacController::PMAC_GSTATUS_DATA_GATHER_START = (0x1 << 17);
-const epicsUInt32 pmacController::PMAC_GSTATUS_RESERVED2 = (0x1 << 18);
-const epicsUInt32 pmacController::PMAC_GSTATUS_DATA_GATHER_ON = (0x1 << 19);
-const epicsUInt32 pmacController::PMAC_GSTATUS_SERVO_ERROR = (0x1 << 20);
-const epicsUInt32 pmacController::PMAC_GSTATUS_CPUTYPE = (0x1 << 21);
-const epicsUInt32 pmacController::PMAC_GSTATUS_REALTIME_INTR_RE = (0x1 << 22);
-const epicsUInt32 pmacController::PMAC_GSTATUS_RESERVED3 = (0x1 << 23);
-
-const epicsUInt32 pmacController::PMAC_HARDWARE_PROB = (PMAC_GSTATUS_REALTIME_INTR |
-                                                        PMAC_GSTATUS_FLASH_ERROR |
-                                                        PMAC_GSTATUS_DPRAM_ERROR |
-                                                        PMAC_GSTATUS_CKSUM_ERROR |
-                                                        PMAC_GSTATUS_WATCHDOG |
-                                                        PMAC_GSTATUS_SERVO_ERROR);
 
 const epicsUInt32 pmacController::PMAX_AXIS_GENERAL_PROB1 = 0;
 const epicsUInt32 pmacController::PMAX_AXIS_GENERAL_PROB2 = (PMAC_STATUS2_DESIRED_STOP |
@@ -1954,7 +1922,7 @@ asynStatus pmacController::fastUpdate(pmacCommandStore *sPtr) {
   //Set any controller specific parameters.
   //Some of these may be used by the axis poll to set axis problem bits.
   if (status == asynSuccess) {
-    hardwareProblem = ((gStatus & PMAC_HARDWARE_PROB) != 0);
+    hardwareProblem = ((gStatus & pHardware_->getGlobalStatusError()) != 0);
     status = setIntegerParam(this->PMAC_C_GlobalStatus_, hardwareProblem);
     if (hardwareProblem) {
       debug(DEBUG_ERROR, functionName, "*** Hardware Problem *** global status [???]",

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -622,33 +622,6 @@ private:
     static const epicsUInt32 PMAC_STATUS2_NA14;
     static const epicsUInt32 PMAC_STATUS2_ASSIGNED_CS;
 
-    /*Global status ???*/
-    static const epicsUInt32 PMAC_GSTATUS_CARD_ADDR;
-    static const epicsUInt32 PMAC_GSTATUS_ALL_CARD_ADDR;
-    static const epicsUInt32 PMAC_GSTATUS_RESERVED;
-    static const epicsUInt32 PMAC_GSTATUS_PHASE_CLK_MISS;
-    static const epicsUInt32 PMAC_GSTATUS_MACRO_RING_ERRORCHECK;
-    static const epicsUInt32 PMAC_GSTATUS_MACRO_RING_COMMS;
-    static const epicsUInt32 PMAC_GSTATUS_TWS_PARITY_ERROR;
-    static const epicsUInt32 PMAC_GSTATUS_CONFIG_ERROR;
-    static const epicsUInt32 PMAC_GSTATUS_ILLEGAL_LVAR;
-    static const epicsUInt32 PMAC_GSTATUS_REALTIME_INTR;
-    static const epicsUInt32 PMAC_GSTATUS_FLASH_ERROR;
-    static const epicsUInt32 PMAC_GSTATUS_DPRAM_ERROR;
-    static const epicsUInt32 PMAC_GSTATUS_CKSUM_ACTIVE;
-    static const epicsUInt32 PMAC_GSTATUS_CKSUM_ERROR;
-    static const epicsUInt32 PMAC_GSTATUS_LEADSCREW_COMP;
-    static const epicsUInt32 PMAC_GSTATUS_WATCHDOG;
-    static const epicsUInt32 PMAC_GSTATUS_SERVO_REQ;
-    static const epicsUInt32 PMAC_GSTATUS_DATA_GATHER_START;
-    static const epicsUInt32 PMAC_GSTATUS_RESERVED2;
-    static const epicsUInt32 PMAC_GSTATUS_DATA_GATHER_ON;
-    static const epicsUInt32 PMAC_GSTATUS_SERVO_ERROR;
-    static const epicsUInt32 PMAC_GSTATUS_CPUTYPE;
-    static const epicsUInt32 PMAC_GSTATUS_REALTIME_INTR_RE;
-    static const epicsUInt32 PMAC_GSTATUS_RESERVED3;
-
-    static const epicsUInt32 PMAC_HARDWARE_PROB;
     static const epicsUInt32 PMAX_AXIS_GENERAL_PROB1;
     static const epicsUInt32 PMAX_AXIS_GENERAL_PROB2;
 

--- a/pmacApp/src/pmacHardwareInterface.h
+++ b/pmacApp/src/pmacHardwareInterface.h
@@ -62,6 +62,8 @@ public:
 
     virtual std::string getGlobalStatusCmd() = 0;
 
+    virtual int getGlobalStatusError() = 0;
+
     virtual asynStatus parseGlobalStatus(const std::string &statusString, globalStatus &status) = 0;
 
     virtual std::string getAxisStatusCmd(int axis) = 0;

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -40,6 +40,36 @@ const int pmacHardwarePower::PMAC_STATUS1_IN_POSITION = (0x1 << 11);
 const int pmacHardwarePower::PMAC_STATUS1_BLOCK_REQUEST = (0x1 << 9);
 const int pmacHardwarePower::PMAC_STATUS1_PHASED_MOTOR = (0x1 << 8);
 
+/*Global status ?*/
+const int pmacHardwarePower::PMAC_GSTATUS_FOREGROUND_WDT_FAULT = (0x1 << 0);
+const int pmacHardwarePower::PMAC_GSTATUS_BACKGROUND_WDT_FAULT = (0x1 << 1);
+const int pmacHardwarePower::PMAC_GSTATUS_PWR_ON_FAULT = (0x1 << 2);
+const int pmacHardwarePower::PMAC_GSTATUS_PROJECT_LOAD_ERROR = (0x1 << 3);
+const int pmacHardwarePower::PMAC_GSTATUS_CONFIG_LOAD_ERROR = (0x1 << 4);
+const int pmacHardwarePower::PMAC_GSTATUS_HW_CHANGE_ERROR = (0x1 << 5);
+const int pmacHardwarePower::PMAC_GSTATUS_FILE_CONFIG_ERROR = (0x1 << 6);
+const int pmacHardwarePower::PMAC_GSTATUS_DEFAULT = (0x1 << 7);
+const int pmacHardwarePower::PMAC_GSTATUS_NO_CLOCKS = (0x1 << 8);
+const int pmacHardwarePower::PMAC_GSTATUS_ABORTALL = (0x1 << 9);
+const int pmacHardwarePower::PMAC_GSTATUS_BUF_SIZE_ERROR = (0x1 << 10);
+const int pmacHardwarePower::PMAC_GSTATUS_FLASH_SIZE_ERROR = (0x1 << 11);
+const int pmacHardwarePower::PMAC_GSTATUS_CK3W_CONFIG_ERROR0 = (0x1 << 12);
+const int pmacHardwarePower::PMAC_GSTATUS_CK3W_CONFIG_ERROR1 = (0x1 << 13);
+const int pmacHardwarePower::PMAC_GSTATUS_CK3W_CONFIG_ERROR2 = (0x1 << 14);
+const int pmacHardwarePower::PMAC_GSTATUS_CK3W_HW_CHANGE = (0x1 << 15);
+
+const int pmacHardwarePower::PMAC_HARDWARE_PROB = (PMAC_GSTATUS_FOREGROUND_WDT_FAULT |
+                                                   PMAC_GSTATUS_BACKGROUND_WDT_FAULT |
+                                                   PMAC_GSTATUS_PROJECT_LOAD_ERROR |
+                                                   PMAC_GSTATUS_CONFIG_LOAD_ERROR |
+                                                   PMAC_GSTATUS_HW_CHANGE_ERROR |
+                                                   PMAC_GSTATUS_FILE_CONFIG_ERROR |
+                                                   PMAC_GSTATUS_NO_CLOCKS |
+                                                   //PMAC_GSTATUS_ABORTALL |
+                                                   PMAC_GSTATUS_BUF_SIZE_ERROR |
+                                                   PMAC_GSTATUS_FLASH_SIZE_ERROR);
+
+
 pmacHardwarePower::pmacHardwarePower() : pmacDebugger("pmacHardwarePower") {
 }
 
@@ -49,6 +79,10 @@ pmacHardwarePower::~pmacHardwarePower() {
 
 std::string pmacHardwarePower::getGlobalStatusCmd() {
   return GLOBAL_STATUS;
+}
+
+int pmacHardwarePower::getGlobalStatusError() {
+  return PMAC_HARDWARE_PROB;
 }
 
 asynStatus

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -41,22 +41,22 @@ const int pmacHardwarePower::PMAC_STATUS1_BLOCK_REQUEST = (0x1 << 9);
 const int pmacHardwarePower::PMAC_STATUS1_PHASED_MOTOR = (0x1 << 8);
 
 /*Global status ?*/
-const int pmacHardwarePower::PMAC_GSTATUS_FOREGROUND_WDT_FAULT = (0x1 << 0);
-const int pmacHardwarePower::PMAC_GSTATUS_BACKGROUND_WDT_FAULT = (0x1 << 1);
-const int pmacHardwarePower::PMAC_GSTATUS_PWR_ON_FAULT = (0x1 << 2);
-const int pmacHardwarePower::PMAC_GSTATUS_PROJECT_LOAD_ERROR = (0x1 << 3);
-const int pmacHardwarePower::PMAC_GSTATUS_CONFIG_LOAD_ERROR = (0x1 << 4);
-const int pmacHardwarePower::PMAC_GSTATUS_HW_CHANGE_ERROR = (0x1 << 5);
-const int pmacHardwarePower::PMAC_GSTATUS_FILE_CONFIG_ERROR = (0x1 << 6);
-const int pmacHardwarePower::PMAC_GSTATUS_DEFAULT = (0x1 << 7);
-const int pmacHardwarePower::PMAC_GSTATUS_NO_CLOCKS = (0x1 << 8);
-const int pmacHardwarePower::PMAC_GSTATUS_ABORTALL = (0x1 << 9);
-const int pmacHardwarePower::PMAC_GSTATUS_BUF_SIZE_ERROR = (0x1 << 10);
-const int pmacHardwarePower::PMAC_GSTATUS_FLASH_SIZE_ERROR = (0x1 << 11);
-const int pmacHardwarePower::PMAC_GSTATUS_CK3W_CONFIG_ERROR0 = (0x1 << 12);
-const int pmacHardwarePower::PMAC_GSTATUS_CK3W_CONFIG_ERROR1 = (0x1 << 13);
-const int pmacHardwarePower::PMAC_GSTATUS_CK3W_CONFIG_ERROR2 = (0x1 << 14);
-const int pmacHardwarePower::PMAC_GSTATUS_CK3W_HW_CHANGE = (0x1 << 15);
+const int pmacHardwarePower::PMAC_GSTATUS_FOREGROUND_WDT_FAULT = (0x1 << 0);      // Foreground soft watchdog timer fault - WDTFault bit 0
+const int pmacHardwarePower::PMAC_GSTATUS_BACKGROUND_WDT_FAULT = (0x1 << 1);      // Background soft watchdog timer fault - WDTFault bit 1
+const int pmacHardwarePower::PMAC_GSTATUS_PWR_ON_FAULT = (0x1 << 2);              // Power-up/reset load fault            - PwrOnFault
+const int pmacHardwarePower::PMAC_GSTATUS_PROJECT_LOAD_ERROR = (0x1 << 3);        // Project load error                   - ProjectLoadErr
+const int pmacHardwarePower::PMAC_GSTATUS_CONFIG_LOAD_ERROR = (0x1 << 4);         // Saved configuration load error       - ConfigLoadErr
+const int pmacHardwarePower::PMAC_GSTATUS_HW_CHANGE_ERROR = (0x1 << 5);           // Hardware change detected             - HWChangeErr
+const int pmacHardwarePower::PMAC_GSTATUS_FILE_CONFIG_ERROR = (0x1 << 6);         // System file configuration error      - FileConfigErr
+const int pmacHardwarePower::PMAC_GSTATUS_DEFAULT = (0x1 << 7);                   // Factory default configuration set    - Default
+const int pmacHardwarePower::PMAC_GSTATUS_NO_CLOCKS = (0x1 << 8);                 // No system clocks found               - NoClocks
+const int pmacHardwarePower::PMAC_GSTATUS_ABORTALL = (0x1 << 9);                  // “Abort all” input                    - AbortAll
+const int pmacHardwarePower::PMAC_GSTATUS_BUF_SIZE_ERROR = (0x1 << 10);           // Insufficient user buffer size error  - BufSizeErr
+const int pmacHardwarePower::PMAC_GSTATUS_FLASH_SIZE_ERROR = (0x1 << 11);         // Insufficient flash size error        - FlashSizeErr
+const int pmacHardwarePower::PMAC_GSTATUS_CK3W_CONFIG_ERROR0 = (0x1 << 12);       // CK3W module configuration error      - CK3WConfigErr bit 0
+const int pmacHardwarePower::PMAC_GSTATUS_CK3W_CONFIG_ERROR1 = (0x1 << 13);       // CK3W module configuration error      - CK3WConfigErr bit 1
+const int pmacHardwarePower::PMAC_GSTATUS_CK3W_CONFIG_ERROR2 = (0x1 << 14);       // CK3W module configuration error      - CK3WConfigErr bit 2
+const int pmacHardwarePower::PMAC_GSTATUS_CK3W_HW_CHANGE = (0x1 << 15);           // CK3W module change detected          - CK3WHWChange
 
 const int pmacHardwarePower::PMAC_HARDWARE_PROB = (PMAC_GSTATUS_FOREGROUND_WDT_FAULT |
                                                    PMAC_GSTATUS_BACKGROUND_WDT_FAULT |
@@ -65,7 +65,7 @@ const int pmacHardwarePower::PMAC_HARDWARE_PROB = (PMAC_GSTATUS_FOREGROUND_WDT_F
                                                    PMAC_GSTATUS_HW_CHANGE_ERROR |
                                                    PMAC_GSTATUS_FILE_CONFIG_ERROR |
                                                    PMAC_GSTATUS_NO_CLOCKS |
-                                                   //PMAC_GSTATUS_ABORTALL |
+                                                   //PMAC_GSTATUS_ABORTALL |  // Not included to not affect CS that ignores the abort input (Coord[x].AbortAllMode=3)
                                                    PMAC_GSTATUS_BUF_SIZE_ERROR |
                                                    PMAC_GSTATUS_FLASH_SIZE_ERROR);
 

--- a/pmacApp/src/pmacHardwarePower.h
+++ b/pmacApp/src/pmacHardwarePower.h
@@ -19,6 +19,8 @@ public:
 
     std::string getGlobalStatusCmd();
 
+    int getGlobalStatusError();
+
     asynStatus parseGlobalStatus(const std::string &statusString, globalStatus &globStatus);
 
     std::string getAxisStatusCmd(int axis);
@@ -87,6 +89,35 @@ private:
     static const int PMAC_STATUS1_IN_POSITION;
     static const int PMAC_STATUS1_BLOCK_REQUEST;
     static const int PMAC_STATUS1_PHASED_MOTOR;
+
+    /*Global status ?*/
+    static const int PMAC_GSTATUS_FOREGROUND_WDT_FAULT;     // (0x1 << 0);
+    static const int PMAC_GSTATUS_BACKGROUND_WDT_FAULT;     // (0x1 << 1);
+    static const int PMAC_GSTATUS_PWR_ON_FAULT;             // (0x1 << 2);
+    static const int PMAC_GSTATUS_PROJECT_LOAD_ERROR;       // (0x1 << 3);
+    static const int PMAC_GSTATUS_CONFIG_LOAD_ERROR;        // (0x1 << 4);
+    static const int PMAC_GSTATUS_HW_CHANGE_ERROR;          // (0x1 << 5);
+    static const int PMAC_GSTATUS_FILE_CONFIG_ERROR;        // (0x1 << 6);
+    static const int PMAC_GSTATUS_DEFAULT;                  // (0x1 << 7);
+    static const int PMAC_GSTATUS_NO_CLOCKS;                // (0x1 << 8);
+    static const int PMAC_GSTATUS_ABORTALL;                 // (0x1 << 9);
+    static const int PMAC_GSTATUS_BUF_SIZE_ERROR;           // (0x1 << 10);
+    static const int PMAC_GSTATUS_FLASH_SIZE_ERROR;         // (0x1 << 11);
+    static const int PMAC_GSTATUS_CK3W_CONFIG_ERROR0;       // (0x1 << 12);
+    static const int PMAC_GSTATUS_CK3W_CONFIG_ERROR1;       // (0x1 << 13);
+    static const int PMAC_GSTATUS_CK3W_CONFIG_ERROR2;       // (0x1 << 14);
+    static const int PMAC_GSTATUS_CK3W_HW_CHANGE;           // (0x1 << 15);
+
+    static const int PMAC_HARDWARE_PROB;    // (PMAC_GSTATUS_FOREGROUND_WDT_FAULT |
+                                            // PMAC_GSTATUS_BACKGROUND_WDT_FAULT |
+                                            // PMAC_GSTATUS_PROJECT_LOAD_ERROR |
+                                            // PMAC_GSTATUS_CONFIG_LOAD_ERROR |
+                                            // PMAC_GSTATUS_HW_CHANGE_ERROR |
+                                            // PMAC_GSTATUS_FILE_CONFIG_ERROR |
+                                            // PMAC_GSTATUS_NO_CLOCKS |
+                                            // //PMAC_GSTATUS_ABORTALL |
+                                            // PMAC_GSTATUS_BUF_SIZE_ERROR |
+                                            // PMAC_GSTATUS_FLASH_SIZE_ERROR);
 
 };
 

--- a/pmacApp/src/pmacHardwareTurbo.cpp
+++ b/pmacApp/src/pmacHardwareTurbo.cpp
@@ -137,11 +137,11 @@ const int pmacHardwareTurbo::PMAC_GSTATUS_REALTIME_INTR_RE = (0x1 << 22);
 const int pmacHardwareTurbo::PMAC_GSTATUS_RESERVED3 = (0x1 << 23);
 
 const int pmacHardwareTurbo::PMAC_HARDWARE_PROB = (PMAC_GSTATUS_REALTIME_INTR |
-                                                        PMAC_GSTATUS_FLASH_ERROR |
-                                                        PMAC_GSTATUS_DPRAM_ERROR |
-                                                        PMAC_GSTATUS_CKSUM_ERROR |
-                                                        PMAC_GSTATUS_WATCHDOG |
-                                                        PMAC_GSTATUS_SERVO_ERROR);
+                                                   PMAC_GSTATUS_FLASH_ERROR |
+                                                   PMAC_GSTATUS_DPRAM_ERROR |
+                                                   PMAC_GSTATUS_CKSUM_ERROR |
+                                                   PMAC_GSTATUS_WATCHDOG |
+                                                   PMAC_GSTATUS_SERVO_ERROR);
 
 pmacHardwareTurbo::pmacHardwareTurbo() : pmacDebugger("pmacHardwareTurbo") {
 }

--- a/pmacApp/src/pmacHardwareTurbo.cpp
+++ b/pmacApp/src/pmacHardwareTurbo.cpp
@@ -110,6 +110,39 @@ const int pmacHardwareTurbo::CS_STATUS2_LOOKAHEAD = (0x1 << 23);
 
 const int pmacHardwareTurbo::CS_STATUS3_LIMIT = (0x1 << 1);
 
+/*Global status ?*/
+const int pmacHardwareTurbo::PMAC_GSTATUS_CARD_ADDR = (0x1 << 0);
+const int pmacHardwareTurbo::PMAC_GSTATUS_ALL_CARD_ADDR = (0x1 << 1);
+const int pmacHardwareTurbo::PMAC_GSTATUS_RESERVED = (0x1 << 2);
+const int pmacHardwareTurbo::PMAC_GSTATUS_PHASE_CLK_MISS = (0x1 << 3);
+const int pmacHardwareTurbo::PMAC_GSTATUS_MACRO_RING_ERRORCHECK = (0x1 << 4);
+const int pmacHardwareTurbo::PMAC_GSTATUS_MACRO_RING_COMMS = (0x1 << 5);
+const int pmacHardwareTurbo::PMAC_GSTATUS_TWS_PARITY_ERROR = (0x1 << 6);
+const int pmacHardwareTurbo::PMAC_GSTATUS_CONFIG_ERROR = (0x1 << 7);
+const int pmacHardwareTurbo::PMAC_GSTATUS_ILLEGAL_LVAR = (0x1 << 8);
+const int pmacHardwareTurbo::PMAC_GSTATUS_REALTIME_INTR = (0x1 << 9);
+const int pmacHardwareTurbo::PMAC_GSTATUS_FLASH_ERROR = (0x1 << 10);
+const int pmacHardwareTurbo::PMAC_GSTATUS_DPRAM_ERROR = (0x1 << 11);
+const int pmacHardwareTurbo::PMAC_GSTATUS_CKSUM_ACTIVE = (0x1 << 12);
+const int pmacHardwareTurbo::PMAC_GSTATUS_CKSUM_ERROR = (0x1 << 13);
+const int pmacHardwareTurbo::PMAC_GSTATUS_LEADSCREW_COMP = (0x1 << 14);
+const int pmacHardwareTurbo::PMAC_GSTATUS_WATCHDOG = (0x1 << 15);
+const int pmacHardwareTurbo::PMAC_GSTATUS_SERVO_REQ = (0x1 << 16);
+const int pmacHardwareTurbo::PMAC_GSTATUS_DATA_GATHER_START = (0x1 << 17);
+const int pmacHardwareTurbo::PMAC_GSTATUS_RESERVED2 = (0x1 << 18);
+const int pmacHardwareTurbo::PMAC_GSTATUS_DATA_GATHER_ON = (0x1 << 19);
+const int pmacHardwareTurbo::PMAC_GSTATUS_SERVO_ERROR = (0x1 << 20);
+const int pmacHardwareTurbo::PMAC_GSTATUS_CPUTYPE = (0x1 << 21);
+const int pmacHardwareTurbo::PMAC_GSTATUS_REALTIME_INTR_RE = (0x1 << 22);
+const int pmacHardwareTurbo::PMAC_GSTATUS_RESERVED3 = (0x1 << 23);
+
+const int pmacHardwareTurbo::PMAC_HARDWARE_PROB = (PMAC_GSTATUS_REALTIME_INTR |
+                                                        PMAC_GSTATUS_FLASH_ERROR |
+                                                        PMAC_GSTATUS_DPRAM_ERROR |
+                                                        PMAC_GSTATUS_CKSUM_ERROR |
+                                                        PMAC_GSTATUS_WATCHDOG |
+                                                        PMAC_GSTATUS_SERVO_ERROR);
+
 pmacHardwareTurbo::pmacHardwareTurbo() : pmacDebugger("pmacHardwareTurbo") {
 }
 
@@ -118,6 +151,10 @@ pmacHardwareTurbo::~pmacHardwareTurbo() {
 
 std::string pmacHardwareTurbo::getGlobalStatusCmd() {
   return GLOBAL_STATUS;
+}
+
+int pmacHardwareTurbo::getGlobalStatusError() {
+  return PMAC_HARDWARE_PROB;
 }
 
 asynStatus

--- a/pmacApp/src/pmacHardwareTurbo.h
+++ b/pmacApp/src/pmacHardwareTurbo.h
@@ -19,6 +19,8 @@ public:
 
     std::string getGlobalStatusCmd();
 
+    int getGlobalStatusError();
+
     asynStatus parseGlobalStatus(const std::string &statusString, globalStatus &globStatus);
 
     std::string getAxisStatusCmd(int axis);
@@ -159,6 +161,39 @@ private:
     static const int CS_STATUS2_LOOKAHEAD;           // (0x1<<23)
 
     static const int CS_STATUS3_LIMIT;               // (0x1<<1)
+
+    /*Global status ???*/
+    static const int PMAC_GSTATUS_CARD_ADDR;                // (0x1 << 0)
+    static const int PMAC_GSTATUS_ALL_CARD_ADDR;            // (0x1 << 1)
+    static const int PMAC_GSTATUS_RESERVED;                 // (0x1 << 2)
+    static const int PMAC_GSTATUS_PHASE_CLK_MISS;           // (0x1 << 3)
+    static const int PMAC_GSTATUS_MACRO_RING_ERRORCHECK;    // (0x1 << 4)
+    static const int PMAC_GSTATUS_MACRO_RING_COMMS;         // (0x1 << 5)
+    static const int PMAC_GSTATUS_TWS_PARITY_ERROR;         // (0x1 << 6)
+    static const int PMAC_GSTATUS_CONFIG_ERROR;             // (0x1 << 7)
+    static const int PMAC_GSTATUS_ILLEGAL_LVAR;             // (0x1 << 8)
+    static const int PMAC_GSTATUS_REALTIME_INTR;            // (0x1 << 9)
+    static const int PMAC_GSTATUS_FLASH_ERROR;              // (0x1 << 10)
+    static const int PMAC_GSTATUS_DPRAM_ERROR;              // (0x1 << 11)
+    static const int PMAC_GSTATUS_CKSUM_ACTIVE;             // (0x1 << 12)
+    static const int PMAC_GSTATUS_CKSUM_ERROR;              // (0x1 << 13)
+    static const int PMAC_GSTATUS_LEADSCREW_COMP;           // (0x1 << 14)
+    static const int PMAC_GSTATUS_WATCHDOG;                 // (0x1 << 15)
+    static const int PMAC_GSTATUS_SERVO_REQ;                // (0x1 << 16)
+    static const int PMAC_GSTATUS_DATA_GATHER_START;        // (0x1 << 17)
+    static const int PMAC_GSTATUS_RESERVED2;                // (0x1 << 18)
+    static const int PMAC_GSTATUS_DATA_GATHER_ON;           // (0x1 << 19)
+    static const int PMAC_GSTATUS_SERVO_ERROR;              // (0x1 << 20)
+    static const int PMAC_GSTATUS_CPUTYPE;                  // (0x1 << 21)
+    static const int PMAC_GSTATUS_REALTIME_INTR_RE;         // (0x1 << 22)
+    static const int PMAC_GSTATUS_RESERVED3;                // (0x1 << 23)
+
+    static const int PMAC_HARDWARE_PROB;    // (PMAC_GSTATUS_REALTIME_INTR |
+                                            //  PMAC_GSTATUS_FLASH_ERROR |
+                                            //  PMAC_GSTATUS_DPRAM_ERROR |
+                                            //  PMAC_GSTATUS_CKSUM_ERROR |
+                                            //  PMAC_GSTATUS_WATCHDOG |
+                                            //  PMAC_GSTATUS_SERVO_ERROR);
 
 };
 


### PR DESCRIPTION
Abstract the global status bits using the hardware interface.

Add PMAC_HARDWARE_PROB for PowerPMAC.
The `AbortAll` is not being used to define a "Hardware problem" because the PowerPMAC permits to abort just some of the coordinate systems, this is useful in cases which more than one system is controlled by the same controller, and just one should be affected by the Abort input - e.g. an air-bearing stage.