### PR TITLE
Revert PR#116

### DIFF
--- a/pmacApp/src/pmacCSAxis.cpp
+++ b/pmacApp/src/pmacCSAxis.cpp
@@ -169,7 +169,7 @@ asynStatus pmacCSAxis::directMove(double position, double min_velocity, double m
   }
 
   // Calculate the real position demand using the resolution and offset and then call the move command
-
+  
   std::stringstream ss;
   ss << "Direct move called for motor [" << this->axisNo_ << "] EGU Position: " << position;
   ss << " Min Velocity: " << min_velocity << " Max velocity: " << max_velocity << " Acceleration: " << acceleration << std::endl;
@@ -395,7 +395,7 @@ asynStatus pmacCSAxis::getAxisStatus(pmacCommandStore *sPtr) {
   previous_position_ = position;
   previous_direction_ = direction;
 
-  moving_ = !cStatus.done_ || deferredMove_ || motorPosChanged_;
+  moving_ = !cStatus.done_ || deferredMove_;
 
   setIntegerParam(pC_->motorStatusDone_, !moving_);
   setIntegerParam(pC_->motorStatusMoving_, moving_);
@@ -405,8 +405,6 @@ asynStatus pmacCSAxis::getAxisStatus(pmacCommandStore *sPtr) {
   setIntegerParam(pC_->motorStatusLowLimit_, cStatus.lowLimit_);
   setIntegerParam(pC_->motorStatusFollowingError_, cStatus.followingError_);
   setIntegerParam(pC_->motorStatusProblem_, cStatus.problem_);
-
-  motorPosChanged_ = 0;
 
   axisProblemFlag = 0;
   if (cStatus.problem_) {

--- a/pmacApp/src/pmacCSAxis.h
+++ b/pmacApp/src/pmacCSAxis.h
@@ -55,7 +55,6 @@ private:
     asynStatus getAxisStatus(pmacCommandStore *sPtr);
 
     int deferredMove_;
-    int motorPosChanged_;
     char deferredCommand_[128];
     int scale_;
     double kinematic_resolution_;

--- a/pmacApp/src/pmacCSController.cpp
+++ b/pmacApp/src/pmacCSController.cpp
@@ -404,23 +404,6 @@ asynStatus pmacCSController::processDeferredMoves(void) {
   return status;
 }
 
-asynStatus pmacCSController::updateCsDemands() {
-  asynStatus status = asynSuccess;
-  pmacCSAxis *pAxis = NULL;
-  static const char *functionName = "updateCsDemands";
-
-  //Turn on the deferred motion flag for the involved axes.
-  for (int axis = 0; axis < numAxes_; axis++) {
-    pAxis = getAxis(axis);
-    if (pAxis != NULL) {
-      if (pAxis->motorPosChanged_ == 0) {
-        pAxis->motorPosChanged_ = 1;
-      }
-    }
-  }
-  return status;
-}
-
 void pmacCSController::setDebugLevel(int level, int axis) {
   // Check if an axis or controller wide debug is to be set
   if (axis == 0) {

--- a/pmacApp/src/pmacCSController.h
+++ b/pmacApp/src/pmacCSController.h
@@ -1,15 +1,15 @@
 /********************************************
- *  pmacCSController.h
- *
+ *  pmacCSController.h 
+ * 
  *  PMAC Asyn Coordinate System Axes based on
  *  the asynMotorController class.
- *
+ * 
  *  For instructions see class file
  *  pmacCSController.cpp
  *
  *  Alan Greer
  *  23 February 2016
- *
+ * 
  ********************************************/
 
 #ifndef pmacCSController_H
@@ -96,8 +96,6 @@ public:
     // Read in the kinematics
     asynStatus storeKinematics();
     asynStatus listKinematic(int csNo, const std::string &type, char *buffer, size_t size);
-
-    asynStatus updateCsDemands();
 
 protected:
     pmacCSAxis **pAxes_; // Array of pointers to axis objects

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -2140,14 +2140,6 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     pAxis->setOffset(value);
     // Direct offset parameter will always match the raw motor
     setDoubleParam(pAxis->axisNo_, PMAC_C_DirectOffset_, value);
-
-    int csNum = this->getAxis(pAxis->axisNo_)->getAxisCSNo();
-    if (csNum > 0) {
-        // Make sure that pmacController->makeCSDemandsConsistent will reset the demand for all axes;
-        csResetAllDemands = true;
-        // Indicate rawMotorChanged to propagate the "movement" to the axes
-        pCSControllers_[csNum]->updateCsDemands();
-    }
   } else if (function == PMAC_C_DirectMove_){
     double baseVelocity = 0.0;
     double velocity = 0.0;
@@ -2180,7 +2172,8 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
           "%s: Setting low soft limit on controller %s, axis %d to 1 count\n",
           functionName, portName, pAxis->axisNo_);
       }
-    } else {
+    }
+    else {
       // Otherwise check if we also need to re-enable the other limit
       if (highLimitCounts == 0) {
         // Set low limit and re-enable the high limit by setting to 1 count


### PR DESCRIPTION
Revert "Merge pull request #116 from dls-controls/motor_Off_Update_CsAxes"

These changes cause a segmentation fault during the IOC boot under certain conditions.

This reverts commit b19a69453c42fc5479ae950a0d01f645beedfb86, reversing changes made to 457c2c83456ca6c0e035b40b0ff0c793c59c1a1a.

The feature added by PR#116 will be fixed and tested in a different branch.