### PR TITLE
Add Busy dependency to Pmac

### DIFF
--- a/etc/builder.py
+++ b/etc/builder.py
@@ -9,7 +9,7 @@ __all__ = ['GeoBrick']
 
 
 class Pmac(Device):
-    Dependencies = (Asyn, MotorLib)
+    Dependencies = (Asyn, MotorLib, Busy)
     AutoInstantiate = True
 
 


### PR DESCRIPTION
Very simple change so you can build IOCs with PowerPMAC/GeoBrick/PMACs without dls_pmac_asyn_motor, as previously the latter provided the Busy dependency that all the brick types need to run