### PR TITLE
Fix motor off updating cs

### DIFF
--- a/pmacApp/src/pmacCSAxis.cpp
+++ b/pmacApp/src/pmacCSAxis.cpp
@@ -169,7 +169,7 @@ asynStatus pmacCSAxis::directMove(double position, double min_velocity, double m
   }
 
   // Calculate the real position demand using the resolution and offset and then call the move command
-  
+
   std::stringstream ss;
   ss << "Direct move called for motor [" << this->axisNo_ << "] EGU Position: " << position;
   ss << " Min Velocity: " << min_velocity << " Max velocity: " << max_velocity << " Acceleration: " << acceleration << std::endl;
@@ -395,7 +395,7 @@ asynStatus pmacCSAxis::getAxisStatus(pmacCommandStore *sPtr) {
   previous_position_ = position;
   previous_direction_ = direction;
 
-  moving_ = !cStatus.done_ || deferredMove_;
+  moving_ = !cStatus.done_ || deferredMove_ || motorPosChanged_;
 
   setIntegerParam(pC_->motorStatusDone_, !moving_);
   setIntegerParam(pC_->motorStatusMoving_, moving_);
@@ -405,6 +405,8 @@ asynStatus pmacCSAxis::getAxisStatus(pmacCommandStore *sPtr) {
   setIntegerParam(pC_->motorStatusLowLimit_, cStatus.lowLimit_);
   setIntegerParam(pC_->motorStatusFollowingError_, cStatus.followingError_);
   setIntegerParam(pC_->motorStatusProblem_, cStatus.problem_);
+
+  motorPosChanged_ = 0;
 
   axisProblemFlag = 0;
   if (cStatus.problem_) {

--- a/pmacApp/src/pmacCSAxis.h
+++ b/pmacApp/src/pmacCSAxis.h
@@ -55,6 +55,7 @@ private:
     asynStatus getAxisStatus(pmacCommandStore *sPtr);
 
     int deferredMove_;
+    int motorPosChanged_;
     char deferredCommand_[128];
     int scale_;
     double kinematic_resolution_;

--- a/pmacApp/src/pmacCSController.cpp
+++ b/pmacApp/src/pmacCSController.cpp
@@ -404,6 +404,23 @@ asynStatus pmacCSController::processDeferredMoves(void) {
   return status;
 }
 
+asynStatus pmacCSController::updateCsDemands(void) {
+  asynStatus status = asynSuccess;
+  pmacCSAxis *pAxis = NULL;
+  static const char *functionName = "updateCsDemands";
+
+  //Turn on the changed motor position flag for the involved axes.
+  for (int axis = 0; axis < numAxes_; axis++) {
+    pAxis = this->getAxis(axis);
+    if (pAxis != NULL) {
+      if (pAxis->motorPosChanged_ == 0) {
+        pAxis->motorPosChanged_ = 1;
+      }
+    }
+  }
+  return status;
+}
+
 void pmacCSController::setDebugLevel(int level, int axis) {
   // Check if an axis or controller wide debug is to be set
   if (axis == 0) {

--- a/pmacApp/src/pmacCSController.h
+++ b/pmacApp/src/pmacCSController.h
@@ -1,15 +1,15 @@
 /********************************************
- *  pmacCSController.h 
- * 
+ *  pmacCSController.h
+ *
  *  PMAC Asyn Coordinate System Axes based on
  *  the asynMotorController class.
- * 
+ *
  *  For instructions see class file
  *  pmacCSController.cpp
  *
  *  Alan Greer
  *  23 February 2016
- * 
+ *
  ********************************************/
 
 #ifndef pmacCSController_H
@@ -96,6 +96,8 @@ public:
     // Read in the kinematics
     asynStatus storeKinematics();
     asynStatus listKinematic(int csNo, const std::string &type, char *buffer, size_t size);
+
+    asynStatus updateCsDemands();
 
 protected:
     pmacCSAxis **pAxes_; // Array of pointers to axis objects

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -2132,16 +2132,26 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     }
 
 
-  }
-  else if (function == PMAC_C_MotorRes_){
+  } else if (function == PMAC_C_MotorRes_){
     pAxis->setResolution(value);
     // Direct resolution parameter will always match the raw motor
     setDoubleParam(pAxis->axisNo_, PMAC_C_DirectRes_, value);
-  }
-  else if (function == PMAC_C_MotorOffset_){
+  } else if (function == PMAC_C_MotorOffset_){
     pAxis->setOffset(value);
     // Direct offset parameter will always match the raw motor
     setDoubleParam(pAxis->axisNo_, PMAC_C_DirectOffset_, value);
+
+    int csNum = this->getAxis(pAxis->axisNo_)->getAxisCSNo();
+    if (csNum > 0) {
+        // Make sure that pmacController->makeCSDemandsConsistent will reset the demand for all axes;
+        csResetAllDemands = true;
+        // Indicate rawMotorChanged to propagate the "movement" to the axes
+        if (pCSControllers_[csNum] != NULL) {
+          pCSControllers_[csNum]->updateCsDemands();
+        } else {
+          debugf(DEBUG_ERROR, functionName, "Motor%d assigned to an undeclared CS ==> CS%d", pAxis->axisNo_ ,csNum);
+        }
+    }
   } else if (function == PMAC_C_DirectMove_){
     double baseVelocity = 0.0;
     double velocity = 0.0;
@@ -2153,8 +2163,7 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     pAxis->setIntegerParam(motorStatusDone_, 0);
     pAxis->callParamCallbacks();
     wakeupPoller();
-  }
-  else if (function == motorLowLimit_) {
+  } else if (function == motorLowLimit_) {
     // Limits in counts
     int lowLimitCounts = int(std::floor(value/pAxis->scale_ + 0.5));
     int highLimitCounts = int(std::floor(pAxis->highLimit_/pAxis->scale_ + 0.5));
@@ -2175,8 +2184,7 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
           "%s: Setting low soft limit on controller %s, axis %d to 1 count\n",
           functionName, portName, pAxis->axisNo_);
       }
-    }
-    else {
+    } else {
       // Otherwise check if we also need to re-enable the other limit
       if (highLimitCounts == 0) {
         // Set low limit and re-enable the high limit by setting to 1 count

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -2132,11 +2132,13 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     }
 
 
-  } else if (function == PMAC_C_MotorRes_){
+  }
+  else if (function == PMAC_C_MotorRes_){
     pAxis->setResolution(value);
     // Direct resolution parameter will always match the raw motor
     setDoubleParam(pAxis->axisNo_, PMAC_C_DirectRes_, value);
-  } else if (function == PMAC_C_MotorOffset_){
+  }
+  else if (function == PMAC_C_MotorOffset_){
     pAxis->setOffset(value);
     // Direct offset parameter will always match the raw motor
     setDoubleParam(pAxis->axisNo_, PMAC_C_DirectOffset_, value);
@@ -2151,7 +2153,8 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     pAxis->setIntegerParam(motorStatusDone_, 0);
     pAxis->callParamCallbacks();
     wakeupPoller();
-  } else if (function == motorLowLimit_) {
+  }
+  else if (function == motorLowLimit_) {
     // Limits in counts
     int lowLimitCounts = int(std::floor(value/pAxis->scale_ + 0.5));
     int highLimitCounts = int(std::floor(pAxis->highLimit_/pAxis->scale_ + 0.5));


### PR DESCRIPTION
This pull request patches the feature of updating the CS axis VAL when the OFF of any motor belonging to the CS changes.

The feature was introduced in R2-6-1, and after removed in R2-6-2 due to a Segmentation Fault occurring when a motor is allocated to a CS not declared in the builder.

