### PR TITLE
Fix trajectories velocity calculation from Velocity mode

### DIFF
--- a/pmacApp/pmc/trajectory_scan_code.pmc
+++ b/pmacApp/pmc/trajectory_scan_code.pmc
@@ -123,64 +123,66 @@ Return
 N102
     Time = Next_Time
     User = Next_User
-    CalculatedBase = CurrentBufferAdr + CurrentIndex
-    Time_Adr = CalculatedBase
-    User_Adr = CalculatedBase
-
 
     If(A_Axis = 1)
         Current_A = Next_A
         A_Vel = Next_A_Vel
     End If
-    A_Adr = CalculatedBase + BufferLength
-    A_Vel_Adr = Z_Adr + BufferLength
     If(B_Axis = 1)
         Current_B = Next_B
         B_Vel = Next_B_Vel
     End If
-    B_Adr = A_Adr + BufferLength
-    B_Vel_Adr = A_Vel_Adr + BufferLength
     If (C_Axis = 1)
         Current_C = Next_C
         C_Vel = Next_C_Vel
     End If
-    C_Adr = B_Adr + BufferLength
-    C_Vel_Adr = B_Vel_Adr + BufferLength
     If (U_Axis = 1)
         Current_U = Next_U
         U_Vel = Next_U_Vel
     End If
-    U_Adr = C_Adr + BufferLength
-    U_Vel_Adr = C_Vel_Adr + BufferLength
     If (V_Axis = 1)
         Current_V = Next_V
         V_Vel = Next_V_Vel
     End If
-    V_Adr = U_Adr + BufferLength
-    V_Vel_Adr = U_Vel_Adr + BufferLength
     If (W_Axis = 1)
         Current_W = Next_W
         W_Vel = Next_W_Vel
     End If
-    W_Adr = V_Adr + BufferLength
-    W_Vel_Adr = V_Vel_Adr + BufferLength
     If (X_Axis = 1)
         Current_X = Next_X
         X_Vel = Next_X_Vel
     End If
-    X_Adr = W_Adr + BufferLength
-    X_Vel_Adr = W_Vel_Adr + BufferLength
     If (Y_Axis = 1)
         Current_Y = Next_Y
         Y_Vel = Next_Y_Vel
     End If
-    Y_Adr = X_Adr + BufferLength
-    Y_Vel_Adr = X_Vel_Adr + BufferLength
     If (Z_Axis = 1)
         Current_Z = Next_Z
         Z_Vel = Next_Z_Vel
     End If
+
+    CalculatedBase = CurrentBufferAdr + CurrentIndex
+    Time_Adr = CalculatedBase
+    User_Adr = CalculatedBase
+
+    A_Adr = CalculatedBase + BufferLength
+    B_Adr = A_Adr + BufferLength
+    C_Adr = B_Adr + BufferLength
+    U_Adr = C_Adr + BufferLength
+    V_Adr = U_Adr + BufferLength
+    W_Adr = V_Adr + BufferLength
+    X_Adr = W_Adr + BufferLength
+    Y_Adr = X_Adr + BufferLength
     Z_Adr = Y_Adr + BufferLength
+
+    A_Vel_Adr = Z_Adr     + BufferLength
+    B_Vel_Adr = A_Vel_Adr + BufferLength
+    C_Vel_Adr = B_Vel_Adr + BufferLength
+    U_Vel_Adr = C_Vel_Adr + BufferLength
+    V_Vel_Adr = U_Vel_Adr + BufferLength
+    W_Vel_Adr = V_Vel_Adr + BufferLength
+    X_Vel_Adr = W_Vel_Adr + BufferLength
+    Y_Vel_Adr = X_Vel_Adr + BufferLength
     Z_Vel_Adr = Y_Vel_Adr + BufferLength
 Return
 

--- a/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
+++ b/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
@@ -6,7 +6,7 @@
 BufferLength = BuffLen                          // BuffLen defined in header file
 BufferAdr_A = 0                                 // BufferAdr defined in header file
 BufferAdr_B = 2 * BufferLength                  // each individual array holds 2 buffers
-Status = 0
+Traj_Status = 0
 AbortTrigger = 0
 Error = 0
 
@@ -19,7 +19,7 @@ Open PROG ProgramNum
 Abs
 FRAX(A,B,C,U,V,W,X,Y,Z)
 
-Status = 1                          // Reset values to defaults
+Traj_Status = 1                     // Reset values to defaults
 AbortTrigger = 0
 Error = 0
 CurrentIndex = 0
@@ -34,7 +34,6 @@ PrevBufferFill = BufferLength       // Set PrevBufferFill to pass outer while lo
 GoSub101                            // Check which axes are required
 GoSub103                            // Set addresses for required axes
 GoSub108                            // set all previous velocities to zero
-GoSub112                            // initialize previous positions
 
 While(AbortTrigger == 0 && Error == 0 && CurrentBufferFill > 0 && PrevBufferFill == BufferLength)
 {
@@ -89,7 +88,7 @@ While(AbortTrigger == 0 && Error == 0 && CurrentBufferFill > 0 && PrevBufferFill
     }
     Else
     {
-        If(Status == 1)
+        If(Traj_Status == 1)
 		{
             // Move to final point if the scan wasn't aborted
             If(AbortTrigger == 0)
@@ -103,9 +102,9 @@ While(AbortTrigger == 0 && Error == 0 && CurrentBufferFill > 0 && PrevBufferFill
 
 Dwell 0                         // Stop program aborting before above lines are complete
 // Set Idle Status if no error occurred
-If(Status == 1)
+If(Traj_Status == 1)
 {
-    Status = 2                  // Set program finished (Idle status)
+    Traj_Status = 2             // Set program finished (Idle status)
 }
 Dwell 200                       // Ensure the driver receives an updated status before killing the program
 Return
@@ -117,7 +116,7 @@ Return
 N101:
     If(Axes > 511)
     {
-        Status = 3
+        Traj_Status = 3
         Error = 1
     }
     Else
@@ -131,9 +130,8 @@ Return
 // *************************************************************************************************
 
 N102:
-    Time = Next_Time(CalculatedBase)
+    PVT_Time = Next_Time(CalculatedBase)
     UserFunc = Next_User(CalculatedBase)
-    VelMode = NextVelMode(CalculatedBase)
 
     If(A_Axis == 1)
     {
@@ -207,13 +205,13 @@ Return
 // *************************************************************************************************
 
 N104:
-    If(Time == 0)
+    If(PVT_Time == 0)
     {                      // Set error and abort if demanded move time is zero
-        Status = 3
+        Traj_Status = 3
         Error = 2
         CMD"A"
         Dwell 0
-        Time = 1000
+        PVT_Time = 1000
     }
 
 
@@ -240,7 +238,7 @@ Return
 
 N110:
     if (Axes > 0) {
-        PVT (Time * 0.001)                        // Set move time
+        PVT (PVT_Time * 0.001)                    // Set move time
         GoSub111
     }
     TotalPoints = TotalPoints + 1

--- a/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
+++ b/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
@@ -6,7 +6,7 @@
 BufferLength = BuffLen                          // BuffLen defined in header file
 BufferAdr_A = 0                                 // BufferAdr defined in header file
 BufferAdr_B = BufferLength                  // each individual array holds 2 buffers
-Traj_Status = 0
+Traj_Status = Traj_StatusInitialised            // Traj_Status = 0
 AbortTrigger = 0
 Error = 0
 
@@ -19,7 +19,7 @@ Open PROG ProgramNum
 Abs
 FRAX(A,B,C,U,V,W,X,Y,Z)
 
-Traj_Status = 1                     // Reset values to defaults
+Traj_Status = Traj_StatusActive                     // Traj_Status = 1: Reset values to defaults
 AbortTrigger = 0
 Error = 0
 CurrentIndex = 0
@@ -88,7 +88,7 @@ While(AbortTrigger == 0 && Error == 0 && CurrentBufferFill > 0 && PrevBufferFill
     }
     Else
     {
-        If(Traj_Status == 1)
+        If(Traj_Status == Traj_StatusActive) // Traj_Status == 1
 		{
             // Move to final point if the scan wasn't aborted
             If(AbortTrigger == 0)
@@ -101,10 +101,10 @@ While(AbortTrigger == 0 && Error == 0 && CurrentBufferFill > 0 && PrevBufferFill
 }
 
 Dwell 0                         // Stop program aborting before above lines are complete
-// Set Idle Status if no error occurred
-If(Traj_Status == 1)
+// Traj_Status == 1: Set Idle Status if no error occurred
+If(Traj_Status == Traj_StatusActive)
 {
-    Traj_Status = 2             // Set program finished (Idle status)
+    Traj_Status = Traj_StatusIdle // Traj_Status = 2: Set program finished (Idle status)
 }
 Dwell 200                       // Ensure the driver receives an updated status before killing the program
 Return
@@ -116,7 +116,7 @@ Return
 N101:
     If(Axes > 511)
     {
-        Traj_Status = 3
+        Traj_Status = Traj_StatusError // Traj_Status = 3
         Error = 1
     }
     Else
@@ -207,7 +207,7 @@ Return
 N104:
     If(PVT_Time == 0)
     {                      // Set error and abort if demanded move time is zero
-        Traj_Status = 3
+        Traj_Status = Traj_StatusError      // Traj_Status = 3
         Error = 2
         CMD"A"
         Dwell 0

--- a/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
+++ b/pmacApp/pmc/trajectory_scan_code_ppmac.pmc
@@ -5,7 +5,7 @@
 // Set Initial Values
 BufferLength = BuffLen                          // BuffLen defined in header file
 BufferAdr_A = 0                                 // BufferAdr defined in header file
-BufferAdr_B = 2 * BufferLength                  // each individual array holds 2 buffers
+BufferAdr_B = BufferLength                  // each individual array holds 2 buffers
 Traj_Status = 0
 AbortTrigger = 0
 Error = 0

--- a/pmacApp/pmc/trajectory_scan_definitions.pmc
+++ b/pmacApp/pmc/trajectory_scan_definitions.pmc
@@ -163,7 +163,7 @@ Z_Axis->Y:$AxisAdr,8
 ; Motion Program Variables
 ; *****************************************************************************************
 
-#define Time                M4059           ; Current coordinate values
+; Current coordinate values
 #define Current_A           Q71
 #define Current_B           Q72
 #define Current_C           Q73
@@ -173,27 +173,30 @@ Z_Axis->Y:$AxisAdr,8
 #define Current_X           Q77
 #define Current_Y           Q78
 #define Current_Z           Q79
+
+; Current velocity values
+#define A_Vel               Q11
+#define B_Vel               Q12
+#define C_Vel               Q13
+#define U_Vel               Q14
+#define V_Vel               Q15
+#define W_Vel               Q16
+#define X_Vel               Q17
+#define Y_Vel               Q18
+#define Z_Vel               Q19
+
+#define Readback_A          Q81
+#define Readback_B          Q82
+#define Readback_C          Q83
+#define Readback_U          Q84
+#define Readback_V          Q85
+#define Readback_W          Q86
+#define Readback_X          Q87
+#define Readback_Y          Q88
+#define Readback_Z          Q89
+
+#define Time                M4059
 #define User                M4060
-
-#define Readback_A           Q81
-#define Readback_B           Q82
-#define Readback_C           Q83
-#define Readback_U           Q84
-#define Readback_V           Q85
-#define Readback_W           Q86
-#define Readback_X           Q87
-#define Readback_Y           Q88
-#define Readback_Z           Q89
-
-#define A_Vel               M4062          ; Current velocity values
-#define B_Vel               M4063
-#define C_Vel               M4064
-#define U_Vel               M4065
-#define V_Vel               M4066
-#define W_Vel               M4067
-#define X_Vel               M4068
-#define Y_Vel               M4069
-#define Z_Vel               M4070
 
 #define CalculatedBase      M4081           ; Calculated temporary variable for Current base address
 
@@ -218,15 +221,6 @@ Error->Y:$VarAdr0E,0,24
 Version->* ; this is deliberately unmapped so that the value assigned survives a brick swap
 Time->L:$VarAdr19
 User->L:$VarAdr1A
-A_Vel->L:$VarAdr1C
-B_Vel->L:$VarAdr1D
-C_Vel->L:$VarAdr1E
-U_Vel->L:$VarAdr1F
-V_Vel->L:$VarAdr20
-W_Vel->L:$VarAdr21
-X_Vel->L:$VarAdr22
-Y_Vel->L:$VarAdr23
-Z_Vel->L:$VarAdr24
 CalculatedBase->L:$VarAdr2E
 
 

--- a/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
+++ b/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
@@ -65,7 +65,12 @@ Z_Axis->u.user:0.8.1
 // EPICS Required Variables
 // *****************************************************************************************
 #define Traj_Status         M4034           // Status of motion program for EPICS
-                                                    // 0: Initialised, 1: Active, 2: Idle, 3: Error
+
+#define Traj_StatusInitialised  0
+#define Traj_StatusActive       1
+#define Traj_StatusIdle         2
+#define Traj_StatusError        3
+
 #define AbortTrigger        M4035           // Abort trigger for EPICS
 #define Axes                M4036           // An int between 1 and 511 specifying which axes to use
 #define BufferLength        M4037           // Length of a single buffer e.g. AX, AY...

--- a/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
+++ b/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
@@ -64,7 +64,7 @@ Z_Axis->u.user:0.8.1
 // *****************************************************************************************
 // EPICS Required Variables
 // *****************************************************************************************
-#define Status              M4034           // Status of motion program for EPICS
+#define Traj_Status         M4034           // Status of motion program for EPICS
                                                     // 0: Initialised, 1: Active, 2: Idle, 3: Error
 #define AbortTrigger        M4035           // Abort trigger for EPICS
 #define Axes                M4036           // An int between 1 and 511 specifying which axes to use
@@ -88,7 +88,7 @@ Z_Axis->u.user:0.8.1
 
 
 // for ppmac set the above M variables as self referenced double floats
-Status->*d
+Traj_Status->*d
 AbortTrigger->*d
 Axes->*d
 BufferLength->*d
@@ -109,7 +109,7 @@ Version->*d
 // Motion Program Variables
 // *****************************************************************************************
 
-global Time                 // Current coordinate values
+global PVT_Time                 // Current coordinate values
 #define Current_A   Q71
 #define Current_B   Q72
 #define Current_C   Q73

--- a/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
+++ b/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
@@ -2,7 +2,7 @@
 // Variables
 // *****************************************************************************************
 #define BuffLen       1000    // Length of buffers
-#define DoubleBuffLen 4000
+#define DoubleBuffLen 2000    // <= 2864 to prevent P-variables/global variables overflow
 
 
 // *****************************************************************************************

--- a/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
+++ b/pmacApp/pmc/trajectory_scan_definitions_ppmac.pmh
@@ -45,7 +45,7 @@ global Next_User(DoubleBuffLen)
 #define W_Axis				M4030
 #define X_Axis				M4031
 #define Y_Axis				M4032
-#define Z_Axis				M4034
+#define Z_Axis				M4033
 
 // User address 0 is the only memory location we allocate explicitly
 // this seems to be required in order to map to bits in the word
@@ -109,40 +109,43 @@ Version->*d
 // Motion Program Variables
 // *****************************************************************************************
 
-global PVT_Time                 // Current coordinate values
-#define Current_A   Q71
-#define Current_B   Q72
-#define Current_C   Q73
-#define Current_U   Q74
-#define Current_V	Q75
-#define Current_W   Q76
-#define Current_X   Q77
-#define Current_Y   Q78
-#define Current_Z   Q79
+// Current coordinate values
+#define Current_A           Q71
+#define Current_B           Q72
+#define Current_C           Q73
+#define Current_U           Q74
+#define Current_V           Q75
+#define Current_W           Q76
+#define Current_X           Q77
+#define Current_Y           Q78
+#define Current_Z           Q79
+
+// Current velocity values
+#define A_Vel               Q11
+#define B_Vel               Q12
+#define C_Vel               Q13
+#define U_Vel               Q14
+#define V_Vel               Q15
+#define W_Vel               Q16
+#define X_Vel               Q17
+#define Y_Vel               Q18
+#define Z_Vel               Q19
+
+#define Readback_A          Q81
+#define Readback_B          Q82
+#define Readback_C          Q83
+#define Readback_U          Q84
+#define Readback_V          Q85
+#define Readback_W          Q86
+#define Readback_X          Q87
+#define Readback_Y          Q88
+#define Readback_Z          Q89
+
+global PVT_Time
 global UserFunc
 
-#define Readback_A           Q81
-#define Readback_B           Q82
-#define Readback_C           Q83
-#define Readback_U           Q84
-#define Readback_V           Q85
-#define Readback_W           Q86
-#define Readback_X           Q87
-#define Readback_Y           Q88
-#define Readback_Z           Q89
-
-global A_Vel                // Current velocity values
-global B_Vel
-global C_Vel
-global U_Vel
-global V_Vel
-global W_Vel
-global X_Vel
-global Y_Vel
-global Z_Vel
 
 global CalculatedBase       // Calculated temporary variable for Current base address
-global InverseTmpTime       // Calculated temporary variable for time in velocity calcs
 
 // *****************************************************************************************
 // Set the version number

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -2985,6 +2985,7 @@ asynStatus pmacController::buildProfile(int csNo) {
       // 1 to 9 axes (0 is error) 111111111 => 1 .. 511
       status = this->tScanIncludedAxes(&axisMask);
       tScanAxisMask_ = axisMask;
+      tScanPendingPoint_ = 0;
       //Check if each axis from the coordinate system is involved in this trajectory scan
       for (int index = 0; index < PMAC_MAX_CS_AXES; index++) {
         if ((1 << index & axisMask) > 0) {
@@ -3015,6 +3016,8 @@ asynStatus pmacController::buildProfile(int csNo) {
       numPointsToBuild--;
     } else {
       debug(DEBUG_ERROR, functionName, "Inconsistent tScanPendingPoint_");
+      debugf(DEBUG_ERROR, functionName, "tScanPendingPoint_==> %d", tScanPendingPoint_);
+      debugf(DEBUG_ERROR, functionName, "tScanAxisMask_==> %d", tScanAxisMask_);
     }
   }
   //Update last time of the previous buffer

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -3646,9 +3646,9 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
     }
     posCmd = false;
     // cmd[9..17] are reserved for axis velocities
-    for (int index = PMAC_MAX_CS_AXES; index < (2*PMAC_MAX_CS_AXES); index++) {
-      if ((1 << (index-PMAC_MAX_CS_AXES) & tScanAxisMask_) > 0) {
-        pHardware_->startAxisPointsCmd(cmd[index], index, writeAddress, tScanPmacBufferSize_,
+    for (int index = 0; index < PMAC_MAX_CS_AXES; index++) {
+      if ((1 << index & tScanAxisMask_) > 0) {
+        pHardware_->startAxisPointsCmd(cmd[index+PMAC_MAX_CS_AXES], index, writeAddress, tScanPmacBufferSize_,
                                        posCmd);
       }
     }
@@ -3675,7 +3675,7 @@ asynStatus pmacController::sendTrajectoryDemands(int buffer) {
             pHardware_->addAxisPointCmd(cmd[index], index, posValue, tScanPmacBufferSize_,
                                         firstVal);
             status = pTrajectory_->getVelocity(index, tScanPointCtr_, &velValue);
-            pHardware_->addAxisPointCmd(cmd[index+PMAC_MAX_CS_AXES], (index+PMAC_MAX_CS_AXES), velValue, tScanPmacBufferSize_,
+            pHardware_->addAxisPointCmd(cmd[index+PMAC_MAX_CS_AXES], index, velValue, tScanPmacBufferSize_,
                                         firstVal);
           }
         }

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -4663,7 +4663,7 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
       if (status != asynSuccess) {
         debug(DEBUG_ERROR, functionName, "Failed to get previous Velocity Mode");
       }
-      else if(prevBuffLastVelMode == 0) {
+      else if(prevBuffLastVelMode == AVERAGE_PREVIOUS_NEXT) {
          // Prev->Next
         prevBuffPosition = tScanPrevBufferPositions[axis][0];
         prevBuffTime = tScanPrevBufferTime;
@@ -4678,7 +4678,7 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
         deltaPos = positions[0] - prevBuffPosition;
         prevBuffVelocity = inverse_deltaTime * deltaPos;
         tScanPrevBufferVelocity[axis]=prevBuffVelocity;
-      } else if(prevBuffLastVelMode == 4) {
+      } else if(prevBuffLastVelMode == AVERAGE_CURRENT_NEXT) {
         // Curr->Next
         prevBuffPosition = tScanPrevBufferPositions[axis][1];
 
@@ -4700,8 +4700,7 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
   }
 
   switch(profileVelMode_[index]) {
-    // Average Previous -> Next
-    case 0:
+    case AVERAGE_PREVIOUS_NEXT:
       if(times[index] <=  0 && times[index+1] <= 0) {
         debugf(DEBUG_ERROR, functionName, "Invalid times (%d and %d) at points %d and %d",
                times[index],times[index+1], index, (index+1));
@@ -4723,8 +4722,7 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
       }
       break;
 
-    // Real Previous -> Current
-    case 1:
+    case REAL_PREVIOUS_CURRENT:
       if(times[index] <=  0) {
         debugf(DEBUG_ERROR, functionName, "Invalid time (%d) at point %d",
                times[index],index);
@@ -4740,8 +4738,7 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
       }
       break;
 
-    // Average Previous -> Current
-    case 2:
+    case AVERAGE_PREVIOUS_CURRENT:
       if(times[index] <=  0) {
         debugf(DEBUG_ERROR, functionName, "Invalid time (%d) at point %d",
                times[index], index);
@@ -4757,13 +4754,11 @@ asynStatus pmacController::tScanCalculateVelocityArray(double *positions, double
       }
       break;
 
-    // Zero
-    case 3:
+    case ZERO_VELOCITY:
       velocities[index] = 0.0;
       break;
 
-    // Average Current -> Next
-    case 4:
+    case AVERAGE_CURRENT_NEXT:
       // Check Next time
       if(times[index+1] <= 0) {
         debugf(DEBUG_ERROR, functionName, "Invalid time (%d) at point %d",

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -354,8 +354,7 @@ public:
     asynStatus updateCsAssignmentParameters();
     asynStatus copyCsReadbackToDemand(bool manual);
     asynStatus tScanBuildProfileArray(double *positions, double *velocities, double *times, int axis, int numPoints);
-    asynStatus tScanCalculateVelocityArray(double *positions, double *velocities, double *times, int index);
-    // asynStatus tScanBuildVelocityProfileArray(double *velocities, int axis, int numPoints);
+    asynStatus tScanCalculateVelocityArray(double *positions, double *velocities, double *times, int numPoints, int index, int csNum, int axis);
     asynStatus tScanIncludedAxes(int *axisMask);
     void registerForLock(asynPortDriver *controller);
 
@@ -567,6 +566,14 @@ private:
     double **tScanVelocities_;      // 2D array of profile velocities (1 array for each axis)
     int *profileUser_;              // Array of profile user values
     int *profileVelMode_;           // Array of profile velocity modes
+    // Used to handle the buffer rollover when the velocities
+    // are calculated from profileVelMode_
+    int tScanPendingPoint_;
+    int tScanPendingPointReady_;
+    double **tScanPrevBufferPositions;  // 2D array for storing the last 2 positions of the buffer (1 array for each axis)
+    double *tScanPrevBufferVelocity;    // Array for storing the last position of the buffer of each axis
+    double tScanPrevBufferTime;         // Stores the last time of the buffer
+
     epicsEventId startEventId_;
     epicsEventId stopEventId_;
 

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -568,6 +568,13 @@ private:
     double **tScanVelocities_;      // 2D array of profile velocities (1 array for each axis)
     int *profileUser_;              // Array of profile user values
     int *profileVelMode_;           // Array of profile velocity modes
+    enum ProfileVelocityMode {      // Profile Velocity Modes - used in the velocity calculation
+        AVERAGE_PREVIOUS_NEXT,      // 0
+        REAL_PREVIOUS_CURRENT,      // 1
+        AVERAGE_PREVIOUS_CURRENT,   // 2
+        ZERO_VELOCITY,              // 3
+        AVERAGE_CURRENT_NEXT        // 4
+    };
     // Used to handle the buffer rollover when the velocities
     // are calculated from profileVelMode_
     int tScanPendingPoint_;

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -300,6 +300,7 @@ public:
 
     // Trajectory scanning methods
     asynStatus initializeProfile(size_t maxPoints);
+    asynStatus handleBufferRollover(int *numPointsToBuild);
     asynStatus buildProfile();
     asynStatus buildProfile(int csNo);
     asynStatus appendToProfile();
@@ -354,6 +355,7 @@ public:
     asynStatus updateCsAssignmentParameters();
     asynStatus copyCsReadbackToDemand(bool manual);
     asynStatus tScanBuildProfileArray(double *positions, double *velocities, double *times, int axis, int numPoints);
+    asynStatus tScanGetPreviousPoint(double *previousPos, double *previousVel, const double *positions, const double *velocities, int numPoints, int index, int csNum, int axis);
     asynStatus tScanCalculateVelocityArray(double *positions, double *velocities, double *times, int numPoints, int index, int csNum, int axis);
     asynStatus tScanIncludedAxes(int *axisMask);
     void registerForLock(asynPortDriver *controller);

--- a/pmacApp/src/pmacHardwareTurbo.cpp
+++ b/pmacApp/src/pmacHardwareTurbo.cpp
@@ -385,11 +385,16 @@ void pmacHardwareTurbo::addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,
   timeCmd[0] = 0;
 }
 
-void pmacHardwareTurbo::startAxisPointsCmd(char *axisCmd, int axis, int addr, int buffSize, bool) {
+void pmacHardwareTurbo::startAxisPointsCmd(char *axisCmd, int axis, int addr, int buffSize, bool posCmd) {
   static const char *functionName = "startAxisPointsCmd";
 
   debugf(DEBUG_FLOW, functionName, "cmd %s, axis %d, addr %d", axisCmd, axis, addr);
-  sprintf(axisCmd, "WL:$%X", addr + ((axis + 1) * buffSize));
+  if(posCmd) {
+    sprintf(axisCmd, "WL:$%X", addr + ((axis + 1) * buffSize));
+  } else {
+    sprintf(axisCmd, "WL:$%X", addr + ((axis + PMAC_MAX_CS_AXES + 1) * buffSize));
+  }
+
 }
 
 void pmacHardwareTurbo::addAxisPointCmd(char *axisCmd, int , double pos, int ,

--- a/pmacApp/src/pmacTrajectory.cpp
+++ b/pmacApp/src/pmacTrajectory.cpp
@@ -294,6 +294,25 @@ asynStatus pmacTrajectory::getUserMode(int index, int *user) {
   return status;
 }
 
+asynStatus pmacTrajectory::getVelocityMode(int index, int *velocityMode) {
+  asynStatus status = asynSuccess;
+  static const char *functionName = "readVelocityMode";
+
+  debug(DEBUG_TRACE, functionName, "Called with index", index);
+
+  // Check the index is valid
+  if (index < 0 || index >= noOfValidPoints_) {
+    debug(DEBUG_ERROR, functionName, "Invalid index requested", index);
+    status = asynError;
+  }
+
+  if (status == asynSuccess) {
+    *velocityMode = profileVelMode_[index];
+  }
+
+  return status;
+}
+
 asynStatus pmacTrajectory::getPosition(int axis, int index, double *position) {
   asynStatus status = asynSuccess;
   static const char *functionName = "readPosition";

--- a/pmacApp/src/pmacTrajectory.cpp
+++ b/pmacApp/src/pmacTrajectory.cpp
@@ -258,7 +258,7 @@ int pmacTrajectory::getNoOfValidPoints() {
 
 asynStatus pmacTrajectory::getTime(int index, int *time) {
   asynStatus status = asynSuccess;
-  static const char *functionName = "readTime";
+  static const char *functionName = "getTime";
 
   debug(DEBUG_TRACE, functionName, "Called with index", index);
 
@@ -277,7 +277,7 @@ asynStatus pmacTrajectory::getTime(int index, int *time) {
 
 asynStatus pmacTrajectory::getUserMode(int index, int *user) {
   asynStatus status = asynSuccess;
-  static const char *functionName = "readUserMode";
+  static const char *functionName = "getUserMode";
 
   debug(DEBUG_TRACE, functionName, "Called with index", index);
 
@@ -296,7 +296,7 @@ asynStatus pmacTrajectory::getUserMode(int index, int *user) {
 
 asynStatus pmacTrajectory::getVelocityMode(int index, int *velocityMode) {
   asynStatus status = asynSuccess;
-  static const char *functionName = "readVelocityMode";
+  static const char *functionName = "getVelocityMode";
 
   debug(DEBUG_TRACE, functionName, "Called with index", index);
 
@@ -315,7 +315,7 @@ asynStatus pmacTrajectory::getVelocityMode(int index, int *velocityMode) {
 
 asynStatus pmacTrajectory::getPosition(int axis, int index, double *position) {
   asynStatus status = asynSuccess;
-  static const char *functionName = "readPosition";
+  static const char *functionName = "getPosition";
 
   debug(DEBUG_TRACE, functionName, "Called with axis", axis);
   debug(DEBUG_TRACE, functionName, "Called with index", index);
@@ -341,7 +341,7 @@ asynStatus pmacTrajectory::getPosition(int axis, int index, double *position) {
 
 asynStatus pmacTrajectory::getVelocity(int axis, int index, double *velocity) {
   asynStatus status = asynSuccess;
-  static const char *functionName = "readVelocity";
+  static const char *functionName = "getVelocity";
   debug(DEBUG_TRACE, functionName, "Called with axis", axis);
   debug(DEBUG_TRACE, functionName, "Called with index", index);
 

--- a/pmacApp/src/pmacTrajectory.cpp
+++ b/pmacApp/src/pmacTrajectory.cpp
@@ -256,17 +256,42 @@ int pmacTrajectory::getNoOfValidPoints() {
   return noOfValidPoints_;
 }
 
-asynStatus pmacTrajectory::getTime(int index, int *time) {
+asynStatus pmacTrajectory::isIndexValid(int index) {
   asynStatus status = asynSuccess;
-  static const char *functionName = "getTime";
+  static const char *functionName = "isIndexValid";
 
-  debug(DEBUG_TRACE, functionName, "Called with index", index);
+  debug(DEBUG_TRACE, functionName);
 
   // Check the index is valid
   if (index < 0 || index >= noOfValidPoints_) {
     debug(DEBUG_ERROR, functionName, "Invalid index requested", index);
     status = asynError;
   }
+  return status;
+}
+
+asynStatus pmacTrajectory::isAxisValid(int axis) {
+  asynStatus status = asynSuccess;
+  static const char *functionName = "isAxisValid";
+
+  debug(DEBUG_TRACE, functionName);
+
+  // Check the axis is valid
+  if (axis < 0 || axis >= noOfAxes_) {
+    debug(DEBUG_ERROR, functionName, "Invalid axis requested", axis);
+    status = asynError;
+  }
+
+  return status;
+}
+
+asynStatus pmacTrajectory::getTime(int index, int *time) {
+  asynStatus status = asynSuccess;
+  static const char *functionName = "getTime";
+
+  debug(DEBUG_TRACE, functionName, "Called with index", index);
+
+  status = this->isIndexValid(index);
 
   if (status == asynSuccess) {
     *time = profileTimes_[index];
@@ -281,11 +306,7 @@ asynStatus pmacTrajectory::getUserMode(int index, int *user) {
 
   debug(DEBUG_TRACE, functionName, "Called with index", index);
 
-  // Check the index is valid
-  if (index < 0 || index >= noOfValidPoints_) {
-    debug(DEBUG_ERROR, functionName, "Invalid index requested", index);
-    status = asynError;
-  }
+  status = this->isIndexValid(index);
 
   if (status == asynSuccess) {
     *user = profileUser_[index];
@@ -300,11 +321,7 @@ asynStatus pmacTrajectory::getVelocityMode(int index, int *velocityMode) {
 
   debug(DEBUG_TRACE, functionName, "Called with index", index);
 
-  // Check the index is valid
-  if (index < 0 || index >= noOfValidPoints_) {
-    debug(DEBUG_ERROR, functionName, "Invalid index requested", index);
-    status = asynError;
-  }
+  status = this->isIndexValid(index);
 
   if (status == asynSuccess) {
     *velocityMode = profileVelMode_[index];
@@ -320,22 +337,14 @@ asynStatus pmacTrajectory::getPosition(int axis, int index, double *position) {
   debug(DEBUG_TRACE, functionName, "Called with axis", axis);
   debug(DEBUG_TRACE, functionName, "Called with index", index);
 
-  // Check the axis is valid
-  if (axis < 0 || axis >= noOfAxes_) {
-    debug(DEBUG_ERROR, functionName, "Invalid axis requested", axis);
-    status = asynError;
-  }
-
-  // Check the index is valid
-  if (index < 0 || index >= noOfValidPoints_) {
-    debug(DEBUG_ERROR, functionName, "Invalid index requested", index);
+  if ((this->isAxisValid(axis)    != asynSuccess) |
+      (this->isIndexValid(index)  != asynSuccess)) {
     status = asynError;
   }
 
   if (status == asynSuccess) {
     *position = profilePositions_[axis][index];
   }
-
   return status;
 }
 
@@ -345,17 +354,11 @@ asynStatus pmacTrajectory::getVelocity(int axis, int index, double *velocity) {
   debug(DEBUG_TRACE, functionName, "Called with axis", axis);
   debug(DEBUG_TRACE, functionName, "Called with index", index);
 
-  // Check the axis is valid
-  if (axis < 0 || axis >= noOfAxes_) {
-    debug(DEBUG_ERROR, functionName, "Invalid axis requested", axis);
+  if ((this->isAxisValid(axis)    != asynSuccess) |
+      (this->isIndexValid(index)  != asynSuccess)) {
     status = asynError;
   }
 
-  // Check the index is valid
-  if (index < 0 || index >= noOfValidPoints_) {
-    debug(DEBUG_ERROR, functionName, "Invalid index requested", index);
-    status = asynError;
-  }
   if (status == asynSuccess) {
     *velocity = profileVelocities_[axis][index];
   }

--- a/pmacApp/src/pmacTrajectory.h
+++ b/pmacApp/src/pmacTrajectory.h
@@ -31,6 +31,8 @@ public:
 
     asynStatus getUserMode(int index, int *user);
 
+    asynStatus getVelocityMode(int index, int *velocity);
+
     asynStatus getPosition(int axis, int index, double *position);
 
     asynStatus getVelocity(int axis, int index, double *velocity);

--- a/pmacApp/src/pmacTrajectory.h
+++ b/pmacApp/src/pmacTrajectory.h
@@ -27,6 +27,10 @@ public:
 
     int getNoOfValidPoints();
 
+    asynStatus isIndexValid(int index);
+
+    asynStatus isAxisValid(int axis);
+
     asynStatus getTime(int index, int *time);
 
     asynStatus getUserMode(int index, int *user);


### PR DESCRIPTION
This PR fixes the trajectories calculation from velocity mode.

- It considers the buffer rollover for the velocity mode needs information (position or time) from the previous or next buffer.
- Applies fixes in indexing for ppmac startAxisPointsCmd.
- Fixes typo M-variable definition in powerpmac motion program.
- Change the definition of the velocities to Q-variables in motion program.
- Fixes BufferAdr_B in ppmac motion
