### PR TITLE
Ensure unit tests are not built until after src directory

### DIFF
--- a/pmacApp/Makefile
+++ b/pmacApp/Makefile
@@ -7,4 +7,5 @@ DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
 DIRS += opi
 DIRS += unitTests
 DIRS += pmc
+unitTests_DEPEND_DIRS += src
 include $(TOP)/configure/RULES_DIRS


### PR DESCRIPTION
Without this change, when cloning the most recent version and compiling with the `-j` flag, the compilation will fail by trying to build the unit tests directory before the source directories have been built.