### PR TITLE
Send command, receive respose using EPICS string records

### DIFF
--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -403,6 +403,8 @@ void pmacController::createAsynParams(void) {
   createParam(PMAC_C_AxisCSString, asynParamInt32, &PMAC_C_AxisCS_);
   createParam(PMAC_C_AxisReadonlyString, asynParamInt32, &PMAC_C_AxisReadonly_);
   createParam(PMAC_C_WriteCmdString, asynParamOctet, &PMAC_C_WriteCmd_);
+  createParam(PMAC_C_WriteReadCmdString, asynParamOctet, &PMAC_C_WriteReadCmd_);
+  createParam(PMAC_C_WriteReadRBVString, asynParamOctet, &PMAC_C_WriteReadRbv_);
   createParam(PMAC_C_KillAxisString, asynParamInt32, &PMAC_C_KillAxis_);
   createParam(PMAC_C_PLCBits00String, asynParamInt32, &PMAC_C_PLCBits00_);
   createParam(PMAC_C_PLCBits01String, asynParamInt32, &PMAC_C_PLCBits01_);
@@ -2440,6 +2442,18 @@ pmacController::writeOctet(asynUser *pasynUser, const char *value, size_t nChars
     // Write the arbitrary string to the PMAC, ignoring a reponse
     strcpy(command, value);
     status = this->immediateWriteRead(command, response);
+  }
+
+  // Added by AJF
+  if (function == PMAC_C_WriteReadCmd_) {
+    // Write the arbitrary string to the PMAC, set the response in the parameter library
+    strcpy(command, value);
+    status = this->immediateWriteRead(command, response);
+    // Strip off the \r
+    response[strlen(response)-1] = '\0';
+    // Set the response in the parameter library
+    status = (asynStatus) setStringParam(addr, PMAC_C_WriteReadRbv_, response);
+    if (status != asynSuccess) return (status);
   }
 
   // Do callbacks so higher layers see any changes

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -61,6 +61,8 @@
 #define PMAC_C_AxisCSString               "PMAC_C_AXIS_CS"
 #define PMAC_C_AxisReadonlyString         "PMAC_C_AXIS_READONLY"
 #define PMAC_C_WriteCmdString             "PMAC_C_WRITE_CMD"
+#define PMAC_C_WriteReadCmdString         "PMAC_C_WRITE_READ_CMD"
+#define PMAC_C_WriteReadRBVString         "PMAC_C_WRITE_READ_RBV"
 #define PMAC_C_KillAxisString             "PMAC_C_KILL_AXIS"
 #define PMAC_C_PLCBits00String            "PMAC_C_PLC_BITS00"
 #define PMAC_C_PLCBits01String            "PMAC_C_PLC_BITS01"
@@ -395,6 +397,8 @@ protected:
     int PMAC_C_AxisCS_;
     int PMAC_C_AxisReadonly_;
     int PMAC_C_WriteCmd_;
+    int PMAC_C_WriteReadCmd_;
+    int PMAC_C_WriteReadRbv_;
     int PMAC_C_KillAxis_;
     int PMAC_C_PLCBits00_;
     int PMAC_C_PLCBits01_;


### PR DESCRIPTION
Add the ability to send any PMAC command from a stringout record and read the response in a stringin record.
Previously, the response was thrown away.
Needed for I24 (at least)!