### PR TITLE
SSH driver bug fix on buffer size

### DIFF
--- a/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
+++ b/pmacApp/powerPmacAsynPortSrc/sshDriver.cpp
@@ -441,14 +441,14 @@ SSHDriverStatus SSHDriver::write(const char *buffer, size_t bufferSize, size_t *
   // Now we need to read back the same numer of bytes, to remove the written string from the buffer
   int bytesToRead = *bytesWritten;
   int bytes = 0;
-  char buff[512];
+  char buff[2048];
   rc = 0;
   int crCount = 0;
 
   // Count the number of \n characters sent
   // Build the expected ECHO string
-  char expected_response[512];
-  memset(expected_response, 0, 512);
+  char expected_response[2048];
+  memset(expected_response, 0, 2048);
   int expected_index = 0;
   for (int index = 0; index < (int)*bytesWritten; index++){
     if (buffer[index] == '\n'){


### PR DESCRIPTION
Hi there, Leandro!

At LNLS, we have a new project under development using deltatau with Pmac IOC. We noticed a problem when instantiating a dynamic variable with the .substitutions file (pmacVariableWrite.template).

To instantiate multiple variables, the `pmacCommandStore::buildCommandString` function generates an addition of 40 variables in a 1024 char. However, the `SSHDriver::write` function needs to perform an ECHO and the static buffer size is 512 char. If the buffer size passed to `SSHDriver::write` is greater than 512 char, an error is accused in the function (no match), generating a false error of connection loss and reconnection with the deltatau controller.

To solve the problem, I changed the buffer size to 2048 char, following the same pattern as the rest of the sshDriver.cpp code.

I am attaching the replacements file for you to reproduce the same problem with the current version.

[mgn-b-pb08.substitutions.txt](https://github.com/user-attachments/files/21025515/mgn-b-pb08.substitutions.txt)
