### PR TITLE
Add etc dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,6 @@ endif
  endef
  $(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir))))
  iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+ etc_DEPEND_DIRS += pmacApp
  iocs_DEPEND_DIRS += etc
  include $(TOP)/configure/RULES_TOP


### PR DESCRIPTION
As described in [PR #131](https://github.com/DiamondLightSource/pmac/pull/131), this pull request adds a build dependency for `etc/`, ensuring that `pmacApp/` is already built. This condition is only valid when `dls-xml-iocbuilder.py` is present.