### PR TITLE
Fix buffer overlap

### DIFF
--- a/pmacApp/src/pmacCSController.cpp
+++ b/pmacApp/src/pmacCSController.cpp
@@ -369,7 +369,7 @@ asynStatus pmacCSController::processDeferredMoves(void) {
     pAxis = getAxis(axis);
     if (pAxis != NULL) {
       if (pAxis->deferredMove_) {
-        sprintf(command, "%s %s", command, pAxis->deferredCommand_);
+        strncat(command, pAxis->deferredCommand_, PMAC_MAXBUF - strlen(command) - 1);
         executeDeferred = 1;
       }
     }

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -2053,6 +2053,7 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
   pmacAxis *pAxis = NULL;
   char command[PMAC_MAXBUF_] = {0};
   char response[PMAC_MAXBUF_] = {0};
+  char auxbuffer[PMAC_MAXBUF_] = {0};
   double encRatio = 1.0;
   epicsInt32 encposition = 0;
   const char *name[128];
@@ -2220,7 +2221,8 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
   } else if (function == PMAC_C_FeedRate_) {
     strcpy(command, "");
     for (int csNo = 1; csNo <= csCount; csNo++) {
-      sprintf(command, "%s &%d%%%lf", command, csNo, value);
+      snprintf(auxbuffer, sizeof(auxbuffer), " &%d%%%lf", csNo, value);
+      strncat(command, auxbuffer, PMAC_MAXBUF_ - strlen(command) -1);
     }
     debug(DEBUG_VARIABLE, functionName, "Feedrate Command", command);
     if (command[0] != 0) {
@@ -4359,6 +4361,7 @@ asynStatus pmacController::processDeferredMoves(void) {
   asynStatus status = asynSuccess;
   char command[PMAC_MAXBUF_] = {0};
   char response[PMAC_MAXBUF_] = {0};
+  char auxbuffer[PMAC_MAXBUF_] = {0};
   pmacAxis *pAxis = NULL;
   static const char *functionName = "processDeferredMoves";
 
@@ -4370,9 +4373,10 @@ asynStatus pmacController::processDeferredMoves(void) {
     pAxis = getAxis(axis);
     if (pAxis != NULL) {
       if (pAxis->deferredMove_) {
-        sprintf(command, "%s #%d%s%.2f", command, pAxis->axisNo_,
+        snprintf(auxbuffer, sizeof(auxbuffer), " #%d%s%.2f", pAxis->axisNo_,
                 pAxis->deferredRelative_ ? "J^" : "J=",
                 pAxis->deferredPosition_);
+        strncat(command, auxbuffer, PMAC_MAXBUF_ - strlen(command) -1);
       }
     }
   }
@@ -4408,6 +4412,7 @@ asynStatus pmacController::executeManualGroup() {
   std::string csPortName;
   char csAssignment[MAX_STRING_SIZE];
   char cmd[PMAC_MAXBUF];
+  char auxbuffer[PMAC_MAXBUF];
   static const char *functionName = "executeManualGroup";
 
   debug(DEBUG_FLOW, functionName);
@@ -4435,7 +4440,8 @@ asynStatus pmacController::executeManualGroup() {
             if (csNo != 0) {
               // Read the assignment string for this axis
               getStringParam(axis, PMAC_C_GroupAssign_, MAX_STRING_SIZE, csAssignment);
-              sprintf(cmd, "%s &%d#%d->%s ", cmd, csNo, axis, csAssignment);
+              snprintf(auxbuffer, sizeof(auxbuffer), " &%d#%d->%s ", csNo, axis, csAssignment);
+              strncat(cmd, auxbuffer, PMAC_MAXBUF - strlen(cmd) - 1);
             }
           }
         }

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -359,14 +359,21 @@ void pmacHardwarePower::addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,
   debugf(DEBUG_FLOW, functionName, "userCmd %s\ntimeCmd %s\nvel %d, user %d, time %d",
          userCmd, timeCmd, userFunc, time);
 
+  char bufferUser[32];
+  char bufferTime[32];
+
   if(firstVal) {
-    sprintf(userCmd, "%s%d", userCmd, userFunc);
-    sprintf(timeCmd, "%s%d", timeCmd, time);
+    snprintf(bufferUser, sizeof(bufferUser), "%d", userFunc);
+    snprintf(bufferTime, sizeof(bufferTime), "%d", time);
   }
   else {
-    sprintf(userCmd, "%s,%d", userCmd, userFunc);
-    sprintf(timeCmd, "%s,%d", timeCmd, time);
+    snprintf(bufferUser, sizeof(bufferUser), ",%d", userFunc);
+    snprintf(bufferTime, sizeof(bufferTime), ",%d", time);
   }
+
+  strncat(userCmd, bufferUser, 1024 - strlen(userCmd) - 1);
+  strncat(timeCmd, bufferTime, 1024 - strlen(timeCmd) - 1);
+
 }
 
 void pmacHardwarePower::startAxisPointsCmd(char *axisCmd, int axis, int addr, int , bool posCmd ) {
@@ -389,12 +396,16 @@ void pmacHardwarePower::addAxisPointCmd(char *axisCmd, int , double pos, int ,
   debugf(DEBUG_FLOW, functionName, "cmd %s, pos %f, firstval %d", axisCmd,
           pos, firstVal);
 
+  char bufferPos[64];
+
   if(firstVal) {
-    sprintf(axisCmd, "%s%g", axisCmd, pos);
+    snprintf(bufferPos, sizeof(bufferPos), "%.12g", pos);
   }
   else {
-    sprintf(axisCmd, "%s,%g", axisCmd, pos);
+    snprintf(bufferPos, sizeof(bufferPos), ",%.12g", pos);
   }
+
+  strncat(axisCmd, bufferPos, 1024 - strlen(axisCmd) - 1);
 }
 
 std::string pmacHardwarePower::getCSEnableCommand(int csNo) {

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -392,11 +392,11 @@ void pmacHardwarePower::startAxisPointsCmd(char *axisCmd, int axis, int addr, in
 void pmacHardwarePower::addAxisPointCmd(char *axisCmd, int , double pos, int ,
                                         bool firstVal) {
   static const char *functionName = "addAxisPointCmd";
+  char bufferPos[64];
 
   debugf(DEBUG_FLOW, functionName, "cmd %s, pos %f, firstval %d", axisCmd,
           pos, firstVal);
 
-  char bufferPos[64];
 
   if(firstVal) {
     snprintf(bufferPos, sizeof(bufferPos), "%.12g", pos);

--- a/pmacApp/src/pmacHardwareTurbo.cpp
+++ b/pmacApp/src/pmacHardwareTurbo.cpp
@@ -377,11 +377,13 @@ void pmacHardwareTurbo::addTrajectoryTimePointCmd(char *userCmd, char *timeCmd,
                                                   int userFunc, int time,
                                                   bool ) {
   static const char *functionName = "addTrajectoryTimePointCmd";
+  char bufferUser[16];
 
   debugf(DEBUG_FLOW, functionName, "userCmd %s\ntimeCmd %s\nuser %d, time %d",
          userCmd, timeCmd, userFunc, time);
 
-  sprintf(userCmd, "%s,$%01X%06X", userCmd, userFunc, time);
+  snprintf(bufferUser, sizeof(bufferUser), ",$%01X%06X", userFunc, time);
+  strncat(userCmd, bufferUser, 1024 - strlen(userCmd) -1);
   timeCmd[0] = 0;
 }
 
@@ -401,10 +403,13 @@ void pmacHardwareTurbo::addAxisPointCmd(char *axisCmd, int , double pos, int ,
         bool ) {
   int64_t ival = 0;
   static const char *functionName = "addAxisPointCmd";
+  char bufferPos[64];
 
   debugf(DEBUG_FLOW, functionName, "cmd %s, pos %f", axisCmd, pos);
   doubleToPMACFloat(pos, &ival);
-  sprintf(axisCmd, "%s,$%lX", axisCmd, (long) ival);
+
+  snprintf(bufferPos, sizeof(bufferPos), ",$%lX", (long) ival);
+  strncat(axisCmd, bufferPos, 1024 - strlen(axisCmd) - 1);
 }
 
 std::string pmacHardwareTurbo::getCSEnableCommand(int csNo) {


### PR DESCRIPTION
This merge addresses a bug caused by buffer overlap in `sprintf` calls where the destination buffer was also used as a source (e.g., sprintf(`command, "%s ...", command)`). This led to string corruption during trajectory building for the PowerPMAC, when compiler optimisations were enabled.
The issue appeared when running from the ioc-pmac, due to the compiler being in later version compared to dev-container

Fix:
- Replaced unsafe `sprintf` usage with `snprintf` and `strncat` to ensure safe string concatenation.

Impact:
- Fixes unpredictable behaviour and corrupted trajectory commands.
