### PR TITLE
Fix CsAxis mapping broken by compiler optimization

### DIFF
--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -1515,7 +1515,7 @@ asynStatus pmacController::mediumUpdate(pmacCommandStore *sPtr) {
       } else {
         setIntegerParam(axis, PMAC_C_GroupCSPortRBV_, 0);
       }
-      std::string cs_cmd = pHardware_->getCSMappingCmd(axisCs, axis).c_str();
+      std::string cs_cmd = pHardware_->getCSMappingCmd(axisCs, axis);
       if (sPtr->checkForItem(cs_cmd)) {
         const std::string result = pHardware_->parseCSMappingResult(
                 sPtr->readValue(cs_cmd));

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -331,11 +331,11 @@ std::string pmacHardwarePower::parseCSMappingResult(const std::string mappingRes
   static const char *functionName = "parseCSMappingResult";
   debugf(DEBUG_FLOW, functionName, "command %s", mappingResult.c_str());
 
-  if (mappingResult.length() > 0) {
-    const char *mapping = mappingResult.substr(mappingResult.length() - 1, 1).c_str();
-    char upper_mapping = (char) toupper(mapping[0]);
-    result = std::string(1, upper_mapping);
+  if (mappingResult.empty()) {
+    return std::string();
   }
+  char upper_mapping = (char) toupper(mappingResult.back());
+  result = std::string(1,upper_mapping);
 
   return result;
 }


### PR DESCRIPTION
This PR fixes an issue where `CsAxis_RBV` records receive an invalid character when compiled on epics-containers with optimization enabled.