### PR TITLE
Add function to allow toggling master control on pmac motors

### DIFF
--- a/pmacApp/Db/dls_pmac_asyn_motor.template
+++ b/pmacApp/Db/dls_pmac_asyn_motor.template
@@ -68,16 +68,16 @@ record(ao, "$(P)$(M):OFF_SET") {
 record(bo, "$(P)$(M):MASTER_CTRL") {
   field(DTYP, "asynInt32")
   field(OUT, "@asyn($(PORT),$(ADDR),0)PMAC_C_AXIS_MASTER_CTRL")
-  field(ZNAM, "0")
-  field(ONAM, "1")
+  field(ZNAM, "Following Off")
+  field(ONAM, "Following On")
 }
 
 record(bi, "$(P)$(M):MASTER_CTRL_RBV") {
   field(DTYP, "asynInt32")
   field(INP, "@asyn($(PORT),$(ADDR),0)PMAC_C_AXIS_MASTER_CTRL_RBV")
   field(SCAN, "I/O Intr")
-  field(ZNAM, "0")
-  field(ONAM, "1")
+  field(ZNAM, "Following Off")
+  field(ONAM, "Following On")
 }
 
 include "motor_in_cs.template"

--- a/pmacApp/Db/dls_pmac_asyn_motor.template
+++ b/pmacApp/Db/dls_pmac_asyn_motor.template
@@ -61,6 +61,17 @@ record(ao, "$(P)$(M):OFF_SET") {
   field(OUT, "@asyn($(PORT),$(ADDR),0)PMAC_OFFSET")
 }
 
+###############################################################
+# Following Mode
+###############################################################
+
+record(bo, "$(P)$(M):MASTER_CTRL") {
+  field(DTYP, "asynInt32")
+  field(OUT, "@asyn($(PORT),$(ADDR),0)PMAC_C_AXIS_MASTER_CTRL")
+  field(ZNAM, "0")
+  field(ONAM, "1")
+}
+
 include "motor_in_cs.template"
 include "eloss_kill_autohome_records.template"
 include "pmacDirectMotor.template"

--- a/pmacApp/Db/dls_pmac_asyn_motor.template
+++ b/pmacApp/Db/dls_pmac_asyn_motor.template
@@ -72,6 +72,14 @@ record(bo, "$(P)$(M):MASTER_CTRL") {
   field(ONAM, "1")
 }
 
+record(bi, "$(P)$(M):MASTER_CTRL_RBV") {
+  field(DTYP, "asynInt32")
+  field(INP, "@asyn($(PORT),$(ADDR),0)PMAC_C_AXIS_MASTER_CTRL_RBV")
+  field(SCAN, "I/O Intr")
+  field(ZNAM, "0")
+  field(ONAM, "1")
+}
+
 include "motor_in_cs.template"
 include "eloss_kill_autohome_records.template"
 include "pmacDirectMotor.template"

--- a/pmacApp/src/pmacAxis.cpp
+++ b/pmacApp/src/pmacAxis.cpp
@@ -275,10 +275,9 @@ void pmacAxis::setMasterControlState(int new_control_state) {
   char response[PMAC_MAXBUF] = {0};
   static const char *functionName = "setMasterControlState";
   debug(DEBUG_TRACE, functionName, "Setting axis master position control", new_control_state);
-  // Set parameter here? or should this be set in poll
-  this->masterControl_ = new_control_state;
   if (this->connected_){
-    sprintf(command, "I%d06=%d", this->axisNo_, new_control_state);
+    std::string master_control_cmd = pC_->pHardware_->getMasterControlCmd(this->axisNo_);
+    sprintf(command, master_control_cmd.c_str(), new_control_state);
     status = pC_->axisWriteRead(command, response);
     if (status != asynSuccess) {
       asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
@@ -341,7 +340,7 @@ asynStatus pmacAxis::move(double position, int relative, double min_velocity, do
       sprintf(command, "%s%s#%d %s%.2f", vel_buff, acc_buff, axisNo_,
               (relative ? "J^" : "J="), position / scale_);
     } else if (this->masterControl_ != 0){
-      debug(DEBUG_TRACE, functionName, "Axis move ignore, as axis is in following mode", command);
+      debug(DEBUG_ERROR, functionName, "Axis move ignore, as axis is in following mode", command);
     } else { /* deferred moves */
       sprintf(command, "%s%s", vel_buff, acc_buff);
       deferredPosition_ = position / scale_;

--- a/pmacApp/src/pmacAxis.cpp
+++ b/pmacApp/src/pmacAxis.cpp
@@ -277,7 +277,7 @@ void pmacAxis::setMasterControlState(int new_control_state) {
   debug(DEBUG_TRACE, functionName, "Setting axis master position control", new_control_state);
   if (this->connected_){
     std::string master_control_cmd = pC_->pHardware_->getMasterControlCmd(this->axisNo_);
-    sprintf(command, master_control_cmd.c_str(), new_control_state);
+    sprintf(command, "%s=%d", master_control_cmd.c_str(), new_control_state);
     status = pC_->axisWriteRead(command, response);
     if (status != asynSuccess) {
       asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,

--- a/pmacApp/src/pmacAxis.cpp
+++ b/pmacApp/src/pmacAxis.cpp
@@ -284,8 +284,6 @@ void pmacAxis::setMasterControlState(int new_control_state) {
       asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
                 "Controller %s Axis %d. %s: setMasterControlState failed to return asynSuccess.\n",
                 pC_->portName, axisNo_, functionName);
-    } else {
-      this->masterControl_ = new_control_state;
     }
   }
 }

--- a/pmacApp/src/pmacAxis.cpp
+++ b/pmacApp/src/pmacAxis.cpp
@@ -64,6 +64,7 @@ pmacAxis::pmacAxis(pmacController *pC, int axisNo)
   asynPrint(pC_->pasynUserSelf, ASYN_TRACE_FLOW, "%s\n", functionName);
 
   //Initialize non-static data members
+  masterControl_= 0;
   assignedCS_ = 0;
   resolution_ = 1.0;
   offset_ = 0.0;
@@ -268,6 +269,27 @@ void pmacAxis::setOffset(double new_offset)
   }
 }
 
+void pmacAxis::setMasterControlState(int new_control_state) {
+  asynStatus status = asynError;
+  char command[PMAC_MAXBUF] = {0};
+  char response[PMAC_MAXBUF] = {0};
+  static const char *functionName = "setMasterControlState";
+  debug(DEBUG_TRACE, functionName, "Setting axis master position control", new_control_state);
+  // Set parameter here? or should this be set in poll
+  this->masterControl_ = new_control_state;
+  if (this->connected_){
+    sprintf(command, "I%d06=%d", this->axisNo_, new_control_state);
+    status = pC_->axisWriteRead(command, response);
+    if (status != asynSuccess) {
+      asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
+                "Controller %s Axis %d. %s: setMasterControlState failed to return asynSuccess.\n",
+                pC_->portName, axisNo_, functionName);
+    } else {
+      this->masterControl_ = new_control_state;
+    }
+  }
+}
+
 double pmacAxis::getOffset()
 {
   return this->offset_;
@@ -317,9 +339,11 @@ asynStatus pmacAxis::move(double position, int relative, double min_velocity, do
       }
     }
 
-    if (pC_->movesDeferred_ == 0) {
+    if ((pC_->movesDeferred_ == 0) && (this->masterControl_ == 0)) {
       sprintf(command, "%s%s#%d %s%.2f", vel_buff, acc_buff, axisNo_,
               (relative ? "J^" : "J="), position / scale_);
+    } else if (this->masterControl_ != 0){
+      debug(DEBUG_TRACE, functionName, "Axis move ignore, as axis is in following mode", command);
     } else { /* deferred moves */
       sprintf(command, "%s%s", vel_buff, acc_buff);
       deferredPosition_ = position / scale_;
@@ -947,7 +971,6 @@ asynStatus pmacAxis::poll(bool *moving) {
 
   return status;
 }
-
 
 int pmacAxis::getAxisCSNo() {
   return assignedCS_;

--- a/pmacApp/src/pmacAxis.h
+++ b/pmacApp/src/pmacAxis.h
@@ -41,6 +41,8 @@ public:
 
     void setOffset(double new_offset);
 
+    void setMasterControlState(int new_control_state);
+
     double getOffset();
 
     void initialSetup(int axisNo);
@@ -83,13 +85,14 @@ private:
     asynStatus getAxisStatus(pmacCommandStore *sPtr);
 
     asynStatus getAxisInitialStatus(void);
-
+    
     int getAxisCSNo();
 
     double getCachedPosition();
 
     double getPosition();
 
+    int masterControl_;
     int assignedCS_;
     double resolution_;
     double offset_;

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -416,6 +416,7 @@ void pmacController::createAsynParams(void) {
   createParam(PMAC_C_AxisBits02String, asynParamInt32, &PMAC_C_AxisBits02_);
   createParam(PMAC_C_AxisBits03String, asynParamInt32, &PMAC_C_AxisBits03_);
   createParam(PMAC_C_AxisMasterCtrlString, asynParamInt32, &PMAC_C_AxisMasterCtrl_);
+  createParam(PMAC_C_AxisMasterCtrlRBVString, asynParamInt32, &PMAC_C_AxisMasterCtrlRBV_);
   createParam(PMAC_C_ProfileUseAxisAString, asynParamInt32, &PMAC_C_ProfileUseAxisA_);
   createParam(PMAC_C_ProfileUseAxisBString, asynParamInt32, &PMAC_C_ProfileUseAxisB_);
   createParam(PMAC_C_ProfileUseAxisCString, asynParamInt32, &PMAC_C_ProfileUseAxisC_);
@@ -1497,6 +1498,21 @@ asynStatus pmacController::mediumUpdate(pmacCommandStore *sPtr) {
       axisCs = this->getAxis(axis)->getAxisCSNo();
     }
 
+    // Get master control mode
+    std::string master_control_cmd = pHardware_->getMasterControlCmd(axis).c_str();
+    if (sPtr->checkForItem(master_control_cmd)) {
+      const std::string result = sPtr->readValue(master_control_cmd);
+      // Set private variable for axis move gating
+      int master_control_mode = stoi(result);
+      this->getAxis(axis)->masterControl_ = master_control_mode;
+      setIntegerParam(axis, PMAC_C_AxisMasterCtrlRBV_, master_control_mode);
+      debugf(DEBUG_VARIABLE, functionName, "Axis %d master control mode:%s",
+        axis, result.c_str());
+    } else {
+      sPtr->addItem(master_control_cmd);
+    }
+    
+    
     //Power pmac coordinate systems are from 0 - 15 so subtract 1
     int power_cs_edit = (cid_ == PMAC_CID_POWER_) ? -1 : 0;
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -415,6 +415,7 @@ void pmacController::createAsynParams(void) {
   createParam(PMAC_C_AxisBits01String, asynParamInt32, &PMAC_C_AxisBits01_);
   createParam(PMAC_C_AxisBits02String, asynParamInt32, &PMAC_C_AxisBits02_);
   createParam(PMAC_C_AxisBits03String, asynParamInt32, &PMAC_C_AxisBits03_);
+  createParam(PMAC_C_AxisMasterCtrlString, asynParamInt32, &PMAC_C_AxisMasterCtrl_);
   createParam(PMAC_C_ProfileUseAxisAString, asynParamInt32, &PMAC_C_ProfileUseAxisA_);
   createParam(PMAC_C_ProfileUseAxisBString, asynParamInt32, &PMAC_C_ProfileUseAxisB_);
   createParam(PMAC_C_ProfileUseAxisCString, asynParamInt32, &PMAC_C_ProfileUseAxisC_);
@@ -2586,6 +2587,9 @@ asynStatus pmacController::writeInt32(asynUser *pasynUser, epicsInt32 value) {
     status = (this->executeManualGroup() == asynSuccess) && status;
   } else if (function == PMAC_C_GroupCSPort_) {
     status = (this->executeManualGroup() == asynSuccess) && status;
+  } else if (function == PMAC_C_AxisMasterCtrl_) {
+    sprintf(command, "Motor[%d].MasterCtrl=%d", pAxis->axisNo_, value);
+    status = (this->immediateWriteRead(command, response) == asynSuccess) && status;
   }
 
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -2132,19 +2132,13 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     double baseVelocity = 0.0;
     double velocity = 0.0;
     double acceleration = 0.0;
-    int master_control = 0;
-    getIntegerParam(pAxis->axisNo_, PMAC_C_AxisMasterCtrl_, &master_control);
-    if (master_control == 0){
-      getDoubleParam(pAxis->axisNo_, motorVelBase_, &baseVelocity);
-      getDoubleParam(pAxis->axisNo_, motorVelocity_, &velocity);
-      getDoubleParam(pAxis->axisNo_, motorAccel_, &acceleration);
-      pAxis->directMove(value, baseVelocity, velocity, acceleration);
-      pAxis->setIntegerParam(motorStatusDone_, 0);
-      pAxis->callParamCallbacks();
-      wakeupPoller();
-    } else {
-      debug(DEBUG_VARIABLE, functionName, "Cannot direct move motor in following mode.");
-    }
+    getDoubleParam(pAxis->axisNo_, motorVelBase_, &baseVelocity);
+    getDoubleParam(pAxis->axisNo_, motorVelocity_, &velocity);
+    getDoubleParam(pAxis->axisNo_, motorAccel_, &acceleration);
+    pAxis->directMove(value, baseVelocity, velocity, acceleration);
+    pAxis->setIntegerParam(motorStatusDone_, 0);
+    pAxis->callParamCallbacks();
+    wakeupPoller();
   } else if (function == motorLowLimit_) {
     // Limits in counts
     int lowLimitCounts = int(std::floor(value/pAxis->scale_ + 0.5));
@@ -2594,8 +2588,7 @@ asynStatus pmacController::writeInt32(asynUser *pasynUser, epicsInt32 value) {
   } else if (function == PMAC_C_GroupCSPort_) {
     status = (this->executeManualGroup() == asynSuccess) && status;
   } else if (function == PMAC_C_AxisMasterCtrl_) {
-    sprintf(command, "Motor[%d].MasterCtrl=%d", pAxis->axisNo_, value);
-    status = (this->immediateWriteRead(command, response) == asynSuccess) && status;
+    pAxis->setMasterControlState(value);
   }
 
 

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -2132,13 +2132,19 @@ asynStatus pmacController::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     double baseVelocity = 0.0;
     double velocity = 0.0;
     double acceleration = 0.0;
-    getDoubleParam(pAxis->axisNo_, motorVelBase_, &baseVelocity);
-    getDoubleParam(pAxis->axisNo_, motorVelocity_, &velocity);
-    getDoubleParam(pAxis->axisNo_, motorAccel_, &acceleration);
-    pAxis->directMove(value, baseVelocity, velocity, acceleration);
-    pAxis->setIntegerParam(motorStatusDone_, 0);
-    pAxis->callParamCallbacks();
-    wakeupPoller();
+    int master_control = 0;
+    getIntegerParam(pAxis->axisNo_, PMAC_C_AxisMasterCtrl_, &master_control);
+    if (master_control == 0){
+      getDoubleParam(pAxis->axisNo_, motorVelBase_, &baseVelocity);
+      getDoubleParam(pAxis->axisNo_, motorVelocity_, &velocity);
+      getDoubleParam(pAxis->axisNo_, motorAccel_, &acceleration);
+      pAxis->directMove(value, baseVelocity, velocity, acceleration);
+      pAxis->setIntegerParam(motorStatusDone_, 0);
+      pAxis->callParamCallbacks();
+      wakeupPoller();
+    } else {
+      debug(DEBUG_VARIABLE, functionName, "Cannot direct move motor in following mode.");
+    }
   } else if (function == motorLowLimit_) {
     // Limits in counts
     int lowLimitCounts = int(std::floor(value/pAxis->scale_ + 0.5));

--- a/pmacApp/src/pmacController.cpp
+++ b/pmacApp/src/pmacController.cpp
@@ -1509,7 +1509,7 @@ asynStatus pmacController::mediumUpdate(pmacCommandStore *sPtr) {
     }
 
     // Get master control mode
-    std::string master_control_cmd = pHardware_->getMasterControlCmd(axis).c_str();
+    std::string master_control_cmd = pHardware_->getMasterControlCmd(axis);
     if (sPtr->checkForItem(master_control_cmd)) {
       const std::string result = sPtr->readValue(master_control_cmd);
       // Set private variable for axis move gating

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -73,6 +73,7 @@
 #define PMAC_C_AxisBits01String           "PMAC_C_AXIS_BITS01"
 #define PMAC_C_AxisBits02String           "PMAC_C_AXIS_BITS02"
 #define PMAC_C_AxisBits03String           "PMAC_C_AXIS_BITS03"
+#define PMAC_C_AxisMasterCtrlString       "PMAC_C_AXIS_MASTER_CTRL"
 
 #define PMAC_C_NoOfMsgsString             "PMAC_C_NO_OF_MSGS"
 #define PMAC_C_TotalBytesWrittenString    "PMAC_C_TBYTES_WRITE"
@@ -407,6 +408,7 @@ protected:
     int PMAC_C_AxisBits01_;
     int PMAC_C_AxisBits02_;
     int PMAC_C_AxisBits03_;
+    int PMAC_C_AxisMasterCtrl_;
     int PMAC_C_ProfileUseAxisA_;
     int PMAC_C_ProfileUseAxisB_;
     int PMAC_C_ProfileUseAxisC_;

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -74,6 +74,7 @@
 #define PMAC_C_AxisBits02String           "PMAC_C_AXIS_BITS02"
 #define PMAC_C_AxisBits03String           "PMAC_C_AXIS_BITS03"
 #define PMAC_C_AxisMasterCtrlString       "PMAC_C_AXIS_MASTER_CTRL"
+#define PMAC_C_AxisMasterCtrlRBVString       "PMAC_C_AXIS_MASTER_CTRL_RBV"
 
 #define PMAC_C_NoOfMsgsString             "PMAC_C_NO_OF_MSGS"
 #define PMAC_C_TotalBytesWrittenString    "PMAC_C_TBYTES_WRITE"
@@ -409,6 +410,7 @@ protected:
     int PMAC_C_AxisBits02_;
     int PMAC_C_AxisBits03_;
     int PMAC_C_AxisMasterCtrl_;
+    int PMAC_C_AxisMasterCtrlRBV_;
     int PMAC_C_ProfileUseAxisA_;
     int PMAC_C_ProfileUseAxisB_;
     int PMAC_C_ProfileUseAxisC_;

--- a/pmacApp/src/pmacController.h
+++ b/pmacApp/src/pmacController.h
@@ -74,7 +74,7 @@
 #define PMAC_C_AxisBits02String           "PMAC_C_AXIS_BITS02"
 #define PMAC_C_AxisBits03String           "PMAC_C_AXIS_BITS03"
 #define PMAC_C_AxisMasterCtrlString       "PMAC_C_AXIS_MASTER_CTRL"
-#define PMAC_C_AxisMasterCtrlRBVString       "PMAC_C_AXIS_MASTER_CTRL_RBV"
+#define PMAC_C_AxisMasterCtrlRBVString    "PMAC_C_AXIS_MASTER_CTRL_RBV"
 
 #define PMAC_C_NoOfMsgsString             "PMAC_C_NO_OF_MSGS"
 #define PMAC_C_TotalBytesWrittenString    "PMAC_C_TBYTES_WRITE"

--- a/pmacApp/src/pmacHardwareInterface.h
+++ b/pmacApp/src/pmacHardwareInterface.h
@@ -81,6 +81,8 @@ public:
     virtual std::string getCSAccTimeCmd(int csNo, double time) = 0;
 
     virtual std::string getCSMappingCmd(int csNo, int axis) = 0;
+    
+    virtual std::string getMasterControlCmd(int axis) = 0;
 
     virtual std::string getCSEnabledCountCmd() = 0;
 

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -20,7 +20,7 @@ const std::string pmacHardwarePower::CS_ACCELERATION_CMD = "Coord[%d].Ta=%f Coor
 // the trailing ; stops clashes from occurring (instead of comma on turbo)
 const std::string pmacHardwarePower::CS_AXIS_MAPPING = "#%d->;";
 const std::string pmacHardwarePower::CS_ENABLED_COUNT = "Sys.MaxCoords";
-const std::string pmacHardwarePower::AXIS_MASTER_CONTROL_CMD = "I%d06";
+const std::string pmacHardwarePower::AXIS_MASTER_CONTROL_CMD = "Motor[%d].MasterCtrl";
 
 const int pmacHardwarePower::PMAC_STATUS1_TRIGGER_MOVE = (0x1 << 31);
 const int pmacHardwarePower::PMAC_STATUS1_HOMING = (0x1 << 30);

--- a/pmacApp/src/pmacHardwarePower.cpp
+++ b/pmacApp/src/pmacHardwarePower.cpp
@@ -20,6 +20,7 @@ const std::string pmacHardwarePower::CS_ACCELERATION_CMD = "Coord[%d].Ta=%f Coor
 // the trailing ; stops clashes from occurring (instead of comma on turbo)
 const std::string pmacHardwarePower::CS_AXIS_MAPPING = "#%d->;";
 const std::string pmacHardwarePower::CS_ENABLED_COUNT = "Sys.MaxCoords";
+const std::string pmacHardwarePower::AXIS_MASTER_CONTROL_CMD = "I%d06";
 
 const int pmacHardwarePower::PMAC_STATUS1_TRIGGER_MOVE = (0x1 << 31);
 const int pmacHardwarePower::PMAC_STATUS1_HOMING = (0x1 << 30);
@@ -338,6 +339,15 @@ std::string pmacHardwarePower::parseCSMappingResult(const std::string mappingRes
   }
 
   return result;
+}
+
+std::string pmacHardwarePower::getMasterControlCmd(int axis) {
+  char cmd[255];
+  static const char *functionName = "getMasterControlCmd";
+
+  debugf(DEBUG_FLOW, functionName, "Axis %d", axis);
+  sprintf(cmd, AXIS_MASTER_CONTROL_CMD.c_str(), axis);
+  return std::string(cmd);
 }
 
 void pmacHardwarePower::startTrajectoryTimePointsCmd(char *userCmd, char *timeCmd,

--- a/pmacApp/src/pmacHardwarePower.h
+++ b/pmacApp/src/pmacHardwarePower.h
@@ -38,6 +38,8 @@ public:
     std::string getCSAccTimeCmd(int csNo, double time);
 
     std::string getCSMappingCmd(int csNo, int axis);
+    
+    std::string getMasterControlCmd(int axis);
 
     std::string getCSEnabledCountCmd();
 
@@ -70,6 +72,7 @@ private:
     static const std::string CS_ACCELERATION_CMD;
     static const std::string CS_AXIS_MAPPING;
     static const std::string CS_ENABLED_COUNT;
+    static const std::string AXIS_MASTER_CONTROL_CMD;
 
     static const int PMAC_STATUS1_TRIGGER_MOVE;
     static const int PMAC_STATUS1_HOMING;

--- a/pmacApp/src/pmacHardwareTurbo.cpp
+++ b/pmacApp/src/pmacHardwareTurbo.cpp
@@ -15,6 +15,8 @@ const std::string pmacHardwareTurbo::CS_VEL_CMD = "&%dQ70=%f ";
 const std::string pmacHardwareTurbo::CS_ACCELERATION_CMD = "I%d87=%f";
 const std::string pmacHardwareTurbo::CS_AXIS_MAPPING = "&%d#%d->,";
 const std::string pmacHardwareTurbo::CS_ENABLED_COUNT = "I68";
+const std::string pmacHardwareTurbo::AXIS_MASTER_CONTROL_CMD = "I%d06";
+
 
 const int pmacHardwareTurbo::PMAC_STATUS1_MAXRAPID_SPEED = (0x1 << 0);
 const int pmacHardwareTurbo::PMAC_STATUS1_ALT_CMNDOUT_MODE = (0x1 << 1);
@@ -361,6 +363,15 @@ std::string pmacHardwareTurbo::getCSEnabledCountCmd(){
 
 std::string pmacHardwareTurbo::parseCSMappingResult(const std::string mappingResult) {
   return mappingResult;
+}
+
+std::string pmacHardwareTurbo::getMasterControlCmd(int axis) {
+  char cmd[255];
+  static const char *functionName = "getMasterControlCmd";
+
+  debugf(DEBUG_FLOW, functionName, "Axis %d", axis);
+  sprintf(cmd, AXIS_MASTER_CONTROL_CMD.c_str(), axis);
+  return std::string(cmd);
 }
 
 void pmacHardwareTurbo::startTrajectoryTimePointsCmd(char *user_cmd, char *time_cmd,

--- a/pmacApp/src/pmacHardwareTurbo.h
+++ b/pmacApp/src/pmacHardwareTurbo.h
@@ -39,6 +39,8 @@ public:
 
     std::string getCSMappingCmd(int csNo, int axis);
 
+    std::string getMasterControlCmd(int axis);
+
     std::string getCSEnabledCountCmd();
 
     std::string parseCSMappingResult(const std::string mappingResult);
@@ -67,6 +69,8 @@ private:
     static const std::string CS_ACCELERATION_CMD;
     static const std::string CS_AXIS_MAPPING;
     static const std::string CS_ENABLED_COUNT;
+    static const std::string AXIS_MASTER_CONTROL_CMD;
+
 
     static const int PMAC_STATUS1_MAXRAPID_SPEED;
     static const int PMAC_STATUS1_ALT_CMNDOUT_MODE;


### PR DESCRIPTION
Fixes #160 

This PR adds a bo `MASTER_CTRL` record to `dls_pmac_asyn_motor.template`, and uses this in `writeInt32` to set a motor's `MasterCtrl` level. An additional if condition is inserted in case of `DirectDemand`, preventing setting a new demand while a motor is in following mode (i.e.,` MasterCtrl=1`).